### PR TITLE
fix: use valid renovate schedule syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   ],
   "timezone": "Europe/London",
   "schedule": [
-    "once a day"
+    "after 4am and before 5am"
   ],
   "minimumReleaseAge": "1 day",
   "packageRules": [

--- a/src/pages/best-roast-chicken-in-london.test.ts
+++ b/src/pages/best-roast-chicken-in-london.test.ts
@@ -81,7 +81,7 @@ vi.mock("astro:assets", () => ({
   })()
 }));
 
-describe("best-roast-chicken-in-london page", () => {
+describe("best-roast-chicken-in-london  page", () => {
   test("renders top roast-chicken posts and comments block", async () => {
     const container = await AstroContainer.create();
     const { default: Page } = await import("./best-roast-chicken-in-london.astro");


### PR DESCRIPTION
## Summary
- Fix invalid `"once a day"` schedule which broke Renovate
- Replace with `"after 4am and before 5am"` — a valid later.js expression that runs Renovate in a 1-hour window daily

🤖 Generated with [Claude Code](https://claude.com/claude-code)