### PR TITLE
docs: add CLAUDE.md with GitHub MCP tool guidance

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(yarn test:*)",
       "Bash(yarn test:e2e tests/e2e/guessthescore.spec.ts --reporter=list)",
-      "Bash(yarn test:e2e tests/e2e/guessthescore.spec.ts --project=chromium --reporter=list)"
+      "Bash(yarn test:e2e tests/e2e/guessthescore.spec.ts --project=chromium --reporter=list)",
+      "Skill(schedule)",
+      "Bash(gh pr:*)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Claude Code Guidelines
+
+## GitHub Integration
+
+**Do NOT use `gh` CLI or `hub` CLI** — they are not installed in this environment.
+
+For all GitHub interactions (viewing PRs, creating PRs, posting comments, checking CI, browsing the repo), use the **GitHub MCP server tools** exclusively. These are functions prefixed with `mcp__github__`, for example:
+
+- `mcp__github__create_pull_request` — create a pull request
+- `mcp__github__list_pull_requests` — list pull requests
+- `mcp__github__get_pull_request` — get PR details
+- `mcp__github__create_issue` — create an issue
+- `mcp__github__list_commits` — list commits
+
+Use `ToolSearch` to discover the full set of available `mcp__github__` tools if needed.


### PR DESCRIPTION
Fixes scheduled task failures where Claude falls back to gh CLI (not installed) instead of using the available mcp__github__ tools for GitHub operations like creating pull requests.

https://claude.ai/code/session_01N5ALAsTiiwXgZuoCSnpk5w