### PR TITLE
fix(a11y): add missing ARIA attributes across nav, comments, and sort UI

### DIFF
--- a/src/components/comment/comment.astro
+++ b/src/components/comment/comment.astro
@@ -69,7 +69,7 @@ const formatDate = (dateString: string): string => {
   <p set:html={safeContent} />
 
   <!-- Reply Button for comment -->
-  <button class="reply-btn" data-target-id={comment.id}> Reply </button>
+  <button class="reply-btn" data-target-id={comment.id} aria-expanded="false" aria-controls={`reply-form-${comment.id}`}> Reply </button>
 
   <div
     class="reply-form-container"
@@ -115,8 +115,9 @@ const formatDate = (dateString: string): string => {
           );
 
           if (formContainer) {
-            formContainer.style.display =
-              formContainer.style.display === "none" ? "block" : "none";
+            const isVisible = formContainer.style.display !== "none";
+            formContainer.style.display = isVisible ? "none" : "block";
+            event.target.setAttribute("aria-expanded", (!isVisible).toString());
           }
         });
       });

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -18,12 +18,12 @@ import SocialLinks from "../social-links/social-links.astro";
 
       <SocialLinks className="socials header-socials" />
 
-      <button id="nav-toggle" aria-label="Toggle Navigation Menu"
+      <button id="nav-toggle" aria-label="Toggle Navigation Menu" aria-expanded="false" aria-controls="nav-menu"
         ><span></span></button
       >
     </div>
 
-    <nav id="nav-menu">
+    <nav id="nav-menu" aria-label="Main navigation">
       <a href="/league-of-roasts">League Of Roasts</a>
       <a href="/best-roast-lists">Best Roasts Lists</a>
       <a href="/maps">Maps</a>
@@ -31,8 +31,8 @@ import SocialLinks from "../social-links/social-links.astro";
       <a href="/search">Search</a>
       <a href="/archive">Archive</a>
       <div class="dropdown">
-        <a href="/about" class="dropdown-toggle"
-          >About <span class="dropdown-arrow">▼</span></a
+        <a href="/about" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false"
+          >About <span class="dropdown-arrow" aria-hidden="true">▼</span></a
         >
         <div class="dropdown-menu">
           <a href="/advertise-with-us">Advertise With Us</a>
@@ -49,7 +49,8 @@ import SocialLinks from "../social-links/social-links.astro";
 
       // Main nav toggle
       navToggle?.addEventListener("click", () => {
-        navToggle.classList.toggle("open");
+        const isOpen = navToggle.classList.toggle("open");
+        navToggle.setAttribute("aria-expanded", isOpen.toString());
         navContainer?.classList.toggle("open");
       });
 
@@ -58,7 +59,8 @@ import SocialLinks from "../social-links/social-links.astro";
         // Only prevent default and toggle on mobile
         if (window.innerWidth < 1024) {
           e.preventDefault();
-          dropdown?.classList.toggle("open");
+          const isOpen = dropdown?.classList.toggle("open");
+          dropdownToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
         }
       });
     });

--- a/src/components/social-links/social-links.astro
+++ b/src/components/social-links/social-links.astro
@@ -14,7 +14,7 @@ const { className = "socials" } = Astro.props;
       rel="noopener noreferrer"
       aria-label="Follow us on Threads"
     >
-      <i class="fab fa-instagram"></i>
+      <i class="fab fa-instagram" aria-hidden="true"></i>
     </a>
   </li>
   <li>
@@ -24,7 +24,7 @@ const { className = "socials" } = Astro.props;
       rel="noopener noreferrer"
       aria-label="Follow us on Bluesky"
     >
-      <i class="fab fa-twitter"></i>
+      <i class="fab fa-twitter" aria-hidden="true"></i>
     </a>
   </li>
   <li>
@@ -34,7 +34,7 @@ const { className = "socials" } = Astro.props;
       rel="noopener noreferrer"
       aria-label="Follow us on Facebook"
     >
-      <i class="fab fa-facebook"></i>
+      <i class="fab fa-facebook" aria-hidden="true"></i>
     </a>
   </li>
   <li>
@@ -44,7 +44,7 @@ const { className = "socials" } = Astro.props;
       rel="noopener noreferrer"
       aria-label="Follow us on Instagram"
     >
-      <i class="fab fa-instagram"></i>
+      <i class="fab fa-instagram" aria-hidden="true"></i>
     </a>
   </li>
 </ul>

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -47,6 +47,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
         type="button"
         className="show-hide-button"
         onClick={() => setShowOptions((prev) => !prev)}
+        aria-expanded={showOptions}
       >
         {showOptions ? "Hide options" : "Show all options / filters"}
       </button>


### PR DESCRIPTION
## Summary

Today is Saturday, so I reviewed all five code-quality categories and picked the one with the most impactful outstanding issues. **Accessibility** had the clearest WCAG failures with the lowest risk of breakage.

### What was wrong

Several interactive controls were missing ARIA state attributes, meaning screen readers and other assistive technology had no programmatic way to know whether UI regions were expanded or collapsed (WCAG 2.1 success criterion 4.1.2 — Name, Role, Value):

| Location | Issue |
|---|---|
| `header.astro` – mobile nav toggle button | No `aria-expanded` or `aria-controls`; state never updated in script |
| `header.astro` – About dropdown link | No `aria-haspopup` or `aria-expanded`; decorative `▼` arrow not hidden from AT |
| `header.astro` – `<nav>` element | No `aria-label` to distinguish from other navigation landmarks |
| `social-links.astro` – all four `<i>` icons | No `aria-hidden="true"`; screen readers could announce raw icon class names instead of the parent link's `aria-label` |
| `sort-posts.tsx` – Show/Hide options button | No `aria-expanded`; panel open/close state not communicated to AT |
| `comment.astro` – Reply button | No `aria-expanded` or `aria-controls`; reply form toggle state not communicated to AT |

### Changes made

- **`src/components/header/header.astro`**
  - `aria-expanded="false"` + `aria-controls="nav-menu"` on the nav-toggle `<button>`
  - `aria-label="Main navigation"` on the `<nav>` element
  - `aria-haspopup="true"` + `aria-expanded="false"` on the dropdown-toggle `<a>`
  - `aria-hidden="true"` on the decorative `▼` arrow `<span>`
  - Script updated to set `aria-expanded` to the live open/closed state on every toggle click

- **`src/components/social-links/social-links.astro`**
  - `aria-hidden="true"` added to all four `<i>` icon elements

- **`src/components/sort-posts/sort-posts.tsx`**
  - `aria-expanded={showOptions}` on the Show/Hide options `<button>`

- **`src/components/comment/comment.astro`**
  - `aria-expanded="false"` + `aria-controls` (pointing to the reply form `id`) on each Reply `<button>`
  - Inline script updated to toggle `aria-expanded` in sync with form visibility

## Test plan

- [x] All 220 existing unit tests pass (`vitest run` — 87 files, 220 tests)
- [ ] Manually verify the mobile nav toggle announces expanded/collapsed state in a screen reader
- [ ] Manually verify the About dropdown announces expanded/collapsed state on mobile
- [ ] Manually verify Reply buttons announce expanded/collapsed state in a screen reader
- [ ] Manually verify sort-posts Show/Hide button state is announced correctly

https://claude.ai/code/session_01YWoKqGydU6PbExPLxi5HTf