### PR TITLE
fix(a11y/seo): canonical URL, viewport meta, labelled search input

### DIFF
--- a/src/components/search/search.astro
+++ b/src/components/search/search.astro
@@ -8,7 +8,9 @@ const { resultLimit = 4 } = Astro.props;
 
 <div x-data="searchComponent" data-result-limit={resultLimit}>
   <form @submit.prevent="handleSearch">
+    <label for="search-input" class="sr-only">Search posts</label>
     <input
+      id="search-input"
       type="text"
       placeholder="Search..."
       x-model="searchTerm"
@@ -18,7 +20,7 @@ const { resultLimit = 4 } = Astro.props;
     <button type="submit">Search</button>
   </form>
 
-  <section class="home-list search-container" x-show="searchResults.length > 0">
+  <section class="home-list search-container" aria-label="Search results" x-show="searchResults.length > 0">
     <ul>
       <template x-for="post in searchResults" :key="post.slug">
         <li class="heading">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,14 +1,18 @@
 ---
 import Footer from "../components/footer/footer.astro";
 import Header from "../components/header/header.astro";
-
-const { pageTitle, description, opengraphImage, halloween, structuredData } =
-  Astro.props;
 import "./layout.css";
 import { SEO } from "astro-seo";
 import logo1 from "../images/logo-1.png";
 
 // import logo3 from "/images/logo-3.png";
+
+const { pageTitle, description, opengraphImage, halloween, structuredData } =
+  Astro.props;
+
+const canonicalURL = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).href
+  : Astro.url.href;
 ---
 
 <html lang="en">
@@ -50,11 +54,12 @@ import logo1 from "../images/logo-1.png";
     <link rel="manifest" href="/favicon/site.webmanifest" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <SEO
       title={pageTitle || "Roast Dinners In London"}
       description={description ||
         "Lord Gravy bringing you a guide to the best and worst roast dinners in London."}
+      canonical={canonicalURL}
       openGraph={{
         basic: {
           title: pageTitle || "Roast Dinners In London",

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -222,6 +222,17 @@ section {
   }
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .substack-signup {
   padding: 1rem;
   text-align: center;


### PR DESCRIPTION
## Summary

Weekly code-quality pass — Sunday 2026-04-12.  
Reviewed all five quality categories (TypeScript, Tests, Performance, Accessibility/SEO, Security) and selected **Accessibility & SEO** as the one with the most impactful outstanding issues.

### Changes

**`src/layouts/BaseLayout.astro`**
- Added canonical `<link>` via `astro-seo`'s `canonical` prop.  
  Every page now emits `<link rel="canonical" href="https://rdldn.co.uk/…">`, computed from `Astro.url.pathname` + `Astro.site` (which is already set to `https://rdldn.co.uk` in `astro.config.mjs`).  
  Without this, search engines may treat pages accessed via alternate URLs as duplicate content and split PageRank.
- Fixed the viewport meta tag from `width=device-width` → `width=device-width, initial-scale=1`.  
  Omitting `initial-scale=1` causes some mobile browsers to render at a non-1× zoom level on first load, which also triggers a Lighthouse/Core Web Vitals warning.

**`src/components/search/search.astro`**
- Added a visually-hidden `<label for="search-input">Search posts</label>` associated with the text input via matching `id="search-input"`.  
  A placeholder alone does not satisfy WCAG 2.1 SC 1.3.1 (Info and Relationships) or SC 3.3.2 (Labels or Instructions) — screen readers announce the label, not the placeholder.
- Added `aria-label="Search results"` to the results `<section>`.  
  Screen readers use landmark labels to help users navigate regions; without one, the section is announced as an unnamed region.

**`src/layouts/layout.css`**
- Promoted the `.sr-only` utility class from `header.css` (scoped to `.nav-container`) to the global stylesheet so any component can use it.

## Test plan

- [ ] Build succeeds (`yarn build` / `astro build`)
- [ ] Every rendered page `<head>` includes a `<link rel="canonical" href="https://rdldn.co.uk/…">` matching the page path
- [ ] Mobile: page loads at 1× zoom in iOS Safari / Chrome Android
- [ ] Search page: label is announced by a screen reader / `axe` browser extension shows no "Form elements must have labels" violation
- [ ] Search results section is identified as a landmark with an accessible name

https://claude.ai/code/session_01LiL9v9Jj4bFteixapoomj9