### PR TITLE
feat(chains): add client-side sort controls by date and rating

### DIFF
--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -76,7 +76,13 @@ const averageRating =
   <div class="no-image-container">
     <section class="post-title centre-with-padding">
       <h2>Reviews of venues owned by {chainName}</h2>
-      {averageRating && <p><strong>Average rating:</strong> {averageRating}</p>}
+      {
+        averageRating && (
+          <p>
+            <strong>Average rating:</strong> {averageRating}
+          </p>
+        )
+      }
     </section>
   </div>
 
@@ -167,8 +173,8 @@ const averageRating =
 
 <script>
   const list = document.getElementById("chains-post-list");
-  const fieldSelect = document.getElementById("sort-field") as HTMLSelectElement | null;
-  const directionSelect = document.getElementById("sort-direction") as HTMLSelectElement | null;
+  const fieldSelect = document.getElementById("sort-field");
+  const directionSelect = document.getElementById("sort-direction");
 
   function sortPosts() {
     if (!list || !fieldSelect || !directionSelect) return;
@@ -178,17 +184,17 @@ const averageRating =
     const items = [...list.querySelectorAll("li")];
 
     items.sort((a, b) => {
-      let aVal: number;
-      let bVal: number;
+      let aVal;
+      let bVal;
 
       if (field === "rating") {
-        const aRating = Number.parseFloat((a as HTMLElement).dataset.rating ?? "");
-        const bRating = Number.parseFloat((b as HTMLElement).dataset.rating ?? "");
+        const aRating = Number.parseFloat(a.dataset.rating ?? "");
+        const bRating = Number.parseFloat(b.dataset.rating ?? "");
         aVal = Number.isNaN(aRating) ? (direction === "desc" ? -Infinity : Infinity) : aRating;
         bVal = Number.isNaN(bRating) ? (direction === "desc" ? -Infinity : Infinity) : bRating;
       } else {
-        aVal = new Date((a as HTMLElement).dataset.date ?? "").getTime();
-        bVal = new Date((b as HTMLElement).dataset.date ?? "").getTime();
+        aVal = new Date(a.dataset.date ?? "").getTime();
+        bVal = new Date(b.dataset.date ?? "").getTime();
       }
 
       return direction === "desc" ? bVal - aVal : aVal - bVal;
@@ -197,6 +203,6 @@ const averageRating =
     items.forEach((item) => list.appendChild(item));
   }
 
-  fieldSelect?.addEventListener("change", sortPosts);
-  directionSelect?.addEventListener("change", sortPosts);
+  fieldSelect.addEventListener("change", sortPosts);
+  directionSelect.addEventListener("change", sortPosts);
 </script>

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -89,16 +89,20 @@ const averageRating =
   {
     posts.length > 0 && (
       <div class="chains-sort-controls">
-        <label for="sort-field">Sort by:</label>
-        <select id="sort-field">
-          <option value="date">Date</option>
-          <option value="rating">Rating</option>
-        </select>
-        <label for="sort-direction">Order:</label>
-        <select id="sort-direction">
-          <option value="desc">Descending</option>
-          <option value="asc">Ascending</option>
-        </select>
+        <div class="sort-group">
+          <label for="sort-field">Sort by:</label>
+          <select id="sort-field">
+            <option value="date">Date</option>
+            <option value="rating">Rating</option>
+          </select>
+        </div>
+        <div class="sort-group">
+          <label for="sort-direction">Order:</label>
+          <select id="sort-direction">
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+          </select>
+        </div>
       </div>
     )
   }
@@ -113,11 +117,11 @@ const averageRating =
               data-date={post.date}
               data-rating={post.ratings?.nodes?.[0]?.name || ""}
             >
-              <h2>
+              <h3>
                 <a href={`/${post.slug}`} rel="noopener noreferrer">
                   <Fragment set:html={post.title} />
                 </a>
-              </h2>
+              </h3>
               <a
                 href={`/${post.slug}`}
                 rel="noopener noreferrer"
@@ -163,7 +167,13 @@ const averageRating =
     align-items: center;
     gap: 1rem;
     flex-wrap: wrap;
-    padding: 1rem 0 0;
+    padding: 1rem 1rem 0;
+  }
+
+  .sort-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .chains-sort-controls select {
@@ -175,6 +185,11 @@ const averageRating =
     max-width: 1700px;
     margin-left: auto !important;
     margin-right: auto !important;
+  }
+
+  li {
+    justify-content: flex-start !important;
+    gap: 0.5rem;
   }
 </style>
 

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -187,33 +187,33 @@ const averageRating =
   const fieldSelect = document.getElementById("sort-field");
   const directionSelect = document.getElementById("sort-direction");
 
-  function sortPosts() {
-    if (!list || !fieldSelect || !directionSelect) return;
+  if (list && fieldSelect instanceof HTMLSelectElement && directionSelect instanceof HTMLSelectElement) {
+    const sortPosts = () => {
+      const field = fieldSelect.value;
+      const direction = directionSelect.value;
+      const items = [...list.querySelectorAll("li")];
 
-    const field = fieldSelect.value;
-    const direction = directionSelect.value;
-    const items = [...list.querySelectorAll("li")];
+      items.sort((a, b) => {
+        let aVal;
+        let bVal;
 
-    items.sort((a, b) => {
-      let aVal;
-      let bVal;
+        if (field === "rating") {
+          const aRating = Number.parseFloat(a.dataset.rating ?? "");
+          const bRating = Number.parseFloat(b.dataset.rating ?? "");
+          aVal = Number.isNaN(aRating) ? (direction === "desc" ? -Infinity : Infinity) : aRating;
+          bVal = Number.isNaN(bRating) ? (direction === "desc" ? -Infinity : Infinity) : bRating;
+        } else {
+          aVal = new Date(a.dataset.date ?? "").getTime();
+          bVal = new Date(b.dataset.date ?? "").getTime();
+        }
 
-      if (field === "rating") {
-        const aRating = Number.parseFloat(a.dataset.rating ?? "");
-        const bRating = Number.parseFloat(b.dataset.rating ?? "");
-        aVal = Number.isNaN(aRating) ? (direction === "desc" ? -Infinity : Infinity) : aRating;
-        bVal = Number.isNaN(bRating) ? (direction === "desc" ? -Infinity : Infinity) : bRating;
-      } else {
-        aVal = new Date(a.dataset.date ?? "").getTime();
-        bVal = new Date(b.dataset.date ?? "").getTime();
-      }
+        return direction === "desc" ? bVal - aVal : aVal - bVal;
+      });
 
-      return direction === "desc" ? bVal - aVal : aVal - bVal;
-    });
+      items.forEach((item) => list.appendChild(item));
+    };
 
-    items.forEach((item) => list.appendChild(item));
+    fieldSelect.addEventListener("change", sortPosts);
+    directionSelect.addEventListener("change", sortPosts);
   }
-
-  fieldSelect.addEventListener("change", sortPosts);
-  directionSelect.addEventListener("change", sortPosts);
 </script>

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -174,7 +174,7 @@ const averageRating =
     margin-top: 1rem !important;
     max-width: 1700px;
     margin-left: auto !important;
-    margin-right: auto;
+    margin-right: auto !important;
   }
 </style>
 

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -180,17 +180,6 @@ const averageRating =
     width: 140px;
   }
 
-  .chains-list {
-    margin-top: 1rem !important;
-    max-width: 1700px;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-
-  li {
-    justify-content: flex-start !important;
-    gap: 0.5rem;
-  }
 </style>
 
 <script>

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -166,8 +166,15 @@ const averageRating =
     padding: 1rem 0 0;
   }
 
+  .chains-sort-controls select {
+    width: 140px;
+  }
+
   .chains-list {
     margin-top: 1rem !important;
+    max-width: 1700px;
+    margin-left: auto !important;
+    margin-right: auto;
   }
 </style>
 

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -70,60 +70,123 @@ export async function getStaticPaths() {
 }
 
 const { chainName, posts } = Astro.props as OwnerPageProps;
+
+const ratings = posts
+  .map((p) => Number.parseFloat(p.ratings?.nodes?.[0]?.name || ""))
+  .filter((r) => !Number.isNaN(r));
+const averageRating =
+  ratings.length > 0
+    ? (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(1)
+    : null;
 ---
 
 <BaseLayout pageTitle={`Roast Dinner Reviews by ${chainName}`}>
   <div class="no-image-container">
     <section class="post-title centre-with-padding">
       <h2>Reviews of venues owned by {chainName}</h2>
+      {averageRating && <p><strong>Average rating:</strong> {averageRating}</p>}
     </section>
   </div>
 
   <section class="home-list">
     {
       posts.length > 0 ? (
-        <ul>
-          {posts.map((post) => (
-            <li class="heading">
-              <h2>
-                <a href={`/${post.slug}`} rel="noopener noreferrer">
-                  <Fragment set:html={post.title} />
-                </a>
-              </h2>
-              <a
-                href={`/${post.slug}`}
-                rel="noopener noreferrer"
-                class="featured-image"
+        <>
+          <div class="sort-posts">
+            <label for="sort-field">Sort by:</label>
+            <select id="sort-field">
+              <option value="rating">Rating</option>
+              <option value="date">Date</option>
+            </select>
+            <label for="sort-direction">Order:</label>
+            <select id="sort-direction">
+              <option value="desc">Descending</option>
+              <option value="asc">Ascending</option>
+            </select>
+          </div>
+          <ul id="chains-post-list">
+            {posts.map((post) => (
+              <li
+                class="heading"
+                data-date={post.date}
+                data-rating={post.ratings?.nodes?.[0]?.name || ""}
               >
-                <img
-                  src={post.featuredImage?.node?.sourceUrl}
-                  alt={
-                    post.featuredImage?.node?.altText ||
-                    `Photo of the roast dinner at ${post.title}`
-                  }
-                  width="400"
-                  height="300"
-                />
-              </a>
-              <p>
-                <strong>Rating:</strong>{" "}
-                {post.ratings?.nodes?.[0]?.name || "N/A"}
-              </p>
-              {post.yearsOfVisit?.nodes?.[0]?.name && (
+                <h2>
+                  <a href={`/${post.slug}`} rel="noopener noreferrer">
+                    <Fragment set:html={post.title} />
+                  </a>
+                </h2>
+                <a
+                  href={`/${post.slug}`}
+                  rel="noopener noreferrer"
+                  class="featured-image"
+                >
+                  <img
+                    src={post.featuredImage?.node?.sourceUrl}
+                    alt={
+                      post.featuredImage?.node?.altText ||
+                      `Photo of the roast dinner at ${post.title}`
+                    }
+                    width="400"
+                    height="300"
+                  />
+                </a>
                 <p>
-                  <strong>Year visited:</strong>{" "}
-                  {post.yearsOfVisit.nodes[0].name}
+                  <strong>Rating:</strong>{" "}
+                  {post.ratings?.nodes?.[0]?.name || "N/A"}
                 </p>
-              )}
-              {post.closedDowns?.nodes?.[0]?.name && (
-                <p>{getClosedStatusLabel(post.closedDowns.nodes[0].name)}</p>
-              )}
-            </li>
-          ))}
-        </ul>
+                {post.yearsOfVisit?.nodes?.[0]?.name && (
+                  <p>
+                    <strong>Year visited:</strong>{" "}
+                    {post.yearsOfVisit.nodes[0].name}
+                  </p>
+                )}
+                {post.closedDowns?.nodes?.[0]?.name && (
+                  <p>{getClosedStatusLabel(post.closedDowns.nodes[0].name)}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
       ) : (
         <p>No reviews found for this chain.</p>
       )
     }
   </section>
 </BaseLayout>
+
+<script>
+  const list = document.getElementById("chains-post-list");
+  const fieldSelect = document.getElementById("sort-field") as HTMLSelectElement | null;
+  const directionSelect = document.getElementById("sort-direction") as HTMLSelectElement | null;
+
+  function sortPosts() {
+    if (!list || !fieldSelect || !directionSelect) return;
+
+    const field = fieldSelect.value;
+    const direction = directionSelect.value;
+    const items = [...list.querySelectorAll("li")];
+
+    items.sort((a, b) => {
+      let aVal: number;
+      let bVal: number;
+
+      if (field === "rating") {
+        const aRating = Number.parseFloat((a as HTMLElement).dataset.rating ?? "");
+        const bRating = Number.parseFloat((b as HTMLElement).dataset.rating ?? "");
+        aVal = Number.isNaN(aRating) ? (direction === "desc" ? -Infinity : Infinity) : aRating;
+        bVal = Number.isNaN(bRating) ? (direction === "desc" ? -Infinity : Infinity) : bRating;
+      } else {
+        aVal = new Date((a as HTMLElement).dataset.date ?? "").getTime();
+        bVal = new Date((b as HTMLElement).dataset.date ?? "").getTime();
+      }
+
+      return direction === "desc" ? bVal - aVal : aVal - bVal;
+    });
+
+    items.forEach((item) => list.appendChild(item));
+  }
+
+  fieldSelect?.addEventListener("change", sortPosts);
+  directionSelect?.addEventListener("change", sortPosts);
+</script>

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -55,14 +55,6 @@ export async function getStaticPaths() {
     props: {
       chainName: data.chainName,
       posts: [...data.posts].sort((a, b) => {
-        const aRating = Number.parseFloat(a.ratings?.nodes?.[0]?.name || "");
-        const bRating = Number.parseFloat(b.ratings?.nodes?.[0]?.name || "");
-        const ratingDiff = bRating - aRating;
-
-        if (!Number.isNaN(ratingDiff) && ratingDiff !== 0) {
-          return ratingDiff;
-        }
-
         return new Date(b.date).getTime() - new Date(a.date).getTime();
       }),
     },
@@ -88,72 +80,90 @@ const averageRating =
     </section>
   </div>
 
-  <section class="home-list">
+  {
+    posts.length > 0 && (
+      <div class="chains-sort-controls">
+        <label for="sort-field">Sort by:</label>
+        <select id="sort-field">
+          <option value="date">Date</option>
+          <option value="rating">Rating</option>
+        </select>
+        <label for="sort-direction">Order:</label>
+        <select id="sort-direction">
+          <option value="desc">Descending</option>
+          <option value="asc">Ascending</option>
+        </select>
+      </div>
+    )
+  }
+
+  <section class="home-list chains-list">
     {
       posts.length > 0 ? (
-        <>
-          <div class="sort-posts">
-            <label for="sort-field">Sort by:</label>
-            <select id="sort-field">
-              <option value="rating">Rating</option>
-              <option value="date">Date</option>
-            </select>
-            <label for="sort-direction">Order:</label>
-            <select id="sort-direction">
-              <option value="desc">Descending</option>
-              <option value="asc">Ascending</option>
-            </select>
-          </div>
-          <ul id="chains-post-list">
-            {posts.map((post) => (
-              <li
-                class="heading"
-                data-date={post.date}
-                data-rating={post.ratings?.nodes?.[0]?.name || ""}
-              >
-                <h2>
-                  <a href={`/${post.slug}`} rel="noopener noreferrer">
-                    <Fragment set:html={post.title} />
-                  </a>
-                </h2>
-                <a
-                  href={`/${post.slug}`}
-                  rel="noopener noreferrer"
-                  class="featured-image"
-                >
-                  <img
-                    src={post.featuredImage?.node?.sourceUrl}
-                    alt={
-                      post.featuredImage?.node?.altText ||
-                      `Photo of the roast dinner at ${post.title}`
-                    }
-                    width="400"
-                    height="300"
-                  />
+        <ul id="chains-post-list">
+          {posts.map((post) => (
+            <li
+              class="heading"
+              data-date={post.date}
+              data-rating={post.ratings?.nodes?.[0]?.name || ""}
+            >
+              <h2>
+                <a href={`/${post.slug}`} rel="noopener noreferrer">
+                  <Fragment set:html={post.title} />
                 </a>
+              </h2>
+              <a
+                href={`/${post.slug}`}
+                rel="noopener noreferrer"
+                class="featured-image"
+              >
+                <img
+                  src={post.featuredImage?.node?.sourceUrl}
+                  alt={
+                    post.featuredImage?.node?.altText ||
+                    `Photo of the roast dinner at ${post.title}`
+                  }
+                  width="400"
+                  height="300"
+                />
+              </a>
+              <p>
+                <strong>Rating:</strong>{" "}
+                {post.ratings?.nodes?.[0]?.name || "N/A"}
+              </p>
+              {post.yearsOfVisit?.nodes?.[0]?.name && (
                 <p>
-                  <strong>Rating:</strong>{" "}
-                  {post.ratings?.nodes?.[0]?.name || "N/A"}
+                  <strong>Year visited:</strong>{" "}
+                  {post.yearsOfVisit.nodes[0].name}
                 </p>
-                {post.yearsOfVisit?.nodes?.[0]?.name && (
-                  <p>
-                    <strong>Year visited:</strong>{" "}
-                    {post.yearsOfVisit.nodes[0].name}
-                  </p>
-                )}
-                {post.closedDowns?.nodes?.[0]?.name && (
-                  <p>{getClosedStatusLabel(post.closedDowns.nodes[0].name)}</p>
-                )}
-              </li>
-            ))}
-          </ul>
-        </>
+              )}
+              {post.closedDowns?.nodes?.[0]?.name && (
+                <p>{getClosedStatusLabel(post.closedDowns.nodes[0].name)}</p>
+              )}
+            </li>
+          ))}
+        </ul>
       ) : (
         <p>No reviews found for this chain.</p>
       )
     }
   </section>
 </BaseLayout>
+
+<style>
+  .chains-sort-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 1rem 0 0;
+  }
+
+  .chains-list {
+    margin-top: 1rem !important;
+  }
+</style>
 
 <script>
   const list = document.getElementById("chains-post-list");

--- a/src/pages/chains/[chain].test.ts
+++ b/src/pages/chains/[chain].test.ts
@@ -154,4 +154,95 @@ describe("chains detail page", () => {
 
     expect(html).toContain("No reviews found for this chain.");
   });
+
+  test("renders sort controls when posts are present", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[chain].astro");
+
+    const html = await container.renderToString(Page, {
+      props: {
+        chainName: "Alpha & Co",
+        posts: [
+          {
+            slug: "alpha-a",
+            title: "Alpha A",
+            featuredImage: { node: { sourceUrl: "https://example.com/a.jpg", altText: "" } },
+            ratings: { nodes: [{ name: "9.0" }] },
+            date: "2025-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    expect(html).toContain('id="sort-field"');
+    expect(html).toContain('id="sort-direction"');
+    expect(html).toContain('value="rating"');
+    expect(html).toContain('value="date"');
+    expect(html).toContain('value="desc"');
+    expect(html).toContain('value="asc"');
+    expect(html).toContain('data-date="2025-01-01T00:00:00.000Z"');
+    expect(html).toContain('data-rating="9.0"');
+  });
+
+  test("does not render sort controls when no posts", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[chain].astro");
+
+    const html = await container.renderToString(Page, {
+      props: { chainName: "No Chain", posts: [] },
+    });
+
+    expect(html).not.toContain('id="sort-field"');
+  });
+
+  test("renders average rating below the title", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[chain].astro");
+
+    const html = await container.renderToString(Page, {
+      props: {
+        chainName: "Alpha & Co",
+        posts: [
+          {
+            slug: "alpha-a",
+            title: "Alpha A",
+            featuredImage: { node: { sourceUrl: "https://example.com/a.jpg", altText: "" } },
+            ratings: { nodes: [{ name: "9.0" }] },
+            date: "2025-01-01T00:00:00.000Z",
+          },
+          {
+            slug: "alpha-b",
+            title: "Alpha B",
+            featuredImage: { node: { sourceUrl: "https://example.com/b.jpg", altText: "" } },
+            ratings: { nodes: [{ name: "7.0" }] },
+            date: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    expect(html).toMatch(/Average rating:<\/strong>\s*8\.0/);
+  });
+
+  test("does not render average rating when no posts have ratings", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[chain].astro");
+
+    const html = await container.renderToString(Page, {
+      props: {
+        chainName: "No Ratings Chain",
+        posts: [
+          {
+            slug: "no-rating",
+            title: "No Rating",
+            featuredImage: { node: { sourceUrl: "https://example.com/nr.jpg", altText: "" } },
+            ratings: { nodes: [{ name: "" }] },
+            date: "2025-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    expect(html).not.toContain("Average rating:");
+  });
 });

--- a/src/pages/chains/[chain].test.ts
+++ b/src/pages/chains/[chain].test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 describe("chains detail page", () => {
-  test("getStaticPaths groups by chain, excludes independent, and sorts posts by rating then date", async () => {
+  test("getStaticPaths groups by chain, excludes independent, and sorts posts by date descending", async () => {
     vi.mocked(getAllRoastDinnerPosts).mockResolvedValue([
       {
         slug: "alpha-newer",
@@ -72,9 +72,9 @@ describe("chains detail page", () => {
     expect(independent).toBeUndefined();
     expect(alpha?.props.chainName).toBe("Alpha & Co");
     expect(alpha?.props.posts.map((post: any) => post.slug)).toEqual([
-      "alpha-high",
       "alpha-newer",
       "alpha-older",
+      "alpha-high",
     ]);
   });
 
@@ -176,8 +176,8 @@ describe("chains detail page", () => {
 
     expect(html).toContain('id="sort-field"');
     expect(html).toContain('id="sort-direction"');
-    expect(html).toContain('value="rating"');
     expect(html).toContain('value="date"');
+    expect(html).toContain('value="rating"');
     expect(html).toContain('value="desc"');
     expect(html).toContain('value="asc"');
     expect(html).toContain('data-date="2025-01-01T00:00:00.000Z"');


### PR DESCRIPTION
Add sort by Date or Rating controls with Ascending/Descending direction, powered by a client-side script that re-orders list items using data attributes. Also display average rating below the page title. Server-side default sort remains rating desc.