### PR TITLE
tests: add unit tests for untested library utilities

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchGraphQL, resetGraphQLRequestCache } from "./api";
+
+const GRAPHQL_URL = "https://blog.rdldn.co.uk/graphql";
+
+function mockFetch(data: unknown, options: { ok?: boolean; errors?: unknown[] } = {}) {
+  const { ok = true, errors } = options;
+  const responseJson = errors ? { errors } : { data };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok,
+      json: vi.fn().mockResolvedValue(responseJson),
+    })
+  );
+}
+
+describe("fetchGraphQL", () => {
+  beforeEach(() => {
+    resetGraphQLRequestCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("makes a POST request to the GraphQL endpoint with the query and variables", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts { nodes { slug } } }";
+
+    await fetchGraphQL(query, { first: 10 });
+
+    expect(fetch).toHaveBeenCalledWith(GRAPHQL_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query, variables: { first: 10 } }),
+    });
+  });
+
+  it("defaults to an empty variables object when none are provided", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts { nodes { slug } } }";
+
+    await fetchGraphQL(query);
+
+    expect(fetch).toHaveBeenCalledWith(
+      GRAPHQL_URL,
+      expect.objectContaining({
+        body: JSON.stringify({ query, variables: {} }),
+      })
+    );
+  });
+
+  it("returns the data field from the GraphQL response", async () => {
+    const data = { posts: { nodes: [{ slug: "test-post" }] } };
+    mockFetch(data);
+
+    const result = await fetchGraphQL("{ posts { nodes { slug } } }");
+
+    expect(result).toEqual(data);
+  });
+
+  it("caches identical requests and only calls fetch once", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts { nodes { slug } } }";
+
+    const result1 = await fetchGraphQL(query);
+    const result2 = await fetchGraphQL(query);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result1).toBe(result2);
+  });
+
+  it("caches concurrent identical requests and only calls fetch once", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts { nodes { slug } } }";
+
+    const [result1, result2] = await Promise.all([fetchGraphQL(query), fetchGraphQL(query)]);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result1).toBe(result2);
+  });
+
+  it("treats requests with different variables as distinct cache entries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ data: { slug: "a" } }) })
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ data: { slug: "b" } }) })
+    );
+    const query = "{ post(slug: $slug) { title } }";
+
+    const r1 = await fetchGraphQL(query, { slug: "a" });
+    const r2 = await fetchGraphQL(query, { slug: "b" });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(r1).toEqual({ slug: "a" });
+    expect(r2).toEqual({ slug: "b" });
+  });
+
+  it("produces the same cache key regardless of variable key order", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts }";
+
+    await fetchGraphQL(query, { b: "2", a: "1" });
+    await fetchGraphQL(query, { a: "1", b: "2" });
+
+    // stableStringify sorts keys, so both calls share a cache entry
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on GraphQL errors and removes the failed request from the cache", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ errors: [{ message: "Not found" }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { posts: [] } }),
+        })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    await expect(fetchGraphQL(query)).rejects.toThrow("GraphQL Error");
+
+    // The failed entry should be evicted so a retry can succeed
+    const result = await fetchGraphQL(query);
+    expect(result).toEqual({ posts: [] });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on non-ok HTTP responses and removes the failed request from the cache", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({ ok: false, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ data: { status: "ok" } }),
+        })
+    );
+    const query = "{ status }";
+
+    await expect(fetchGraphQL(query)).rejects.toThrow("GraphQL Error");
+
+    const result = await fetchGraphQL(query);
+    expect(result).toEqual({ status: "ok" });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("includes GraphQL error details in the thrown error message", async () => {
+    const errors = [{ message: "Unauthorized" }];
+    mockFetch(null, { errors });
+
+    await expect(fetchGraphQL("{ me }")).rejects.toThrow(JSON.stringify(errors));
+  });
+
+  it("resetGraphQLRequestCache clears the cache so subsequent calls re-fetch", async () => {
+    mockFetch({ posts: [] });
+    const query = "{ posts { nodes { slug } } }";
+
+    await fetchGraphQL(query);
+    resetGraphQLRequestCache();
+
+    // After reset the second call must hit the network again
+    vi.unstubAllGlobals();
+    mockFetch({ posts: [{ slug: "new" }] });
+
+    const result = await fetchGraphQL(query);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ posts: [{ slug: "new" }] });
+  });
+});

--- a/src/lib/fetchAllSlugs.test.ts
+++ b/src/lib/fetchAllSlugs.test.ts
@@ -1,0 +1,105 @@
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchGraphQL } from "./api";
+import { fetchAllSlugs } from "./fetchAllSlugs";
+
+vi.mock("./api", () => ({
+  fetchGraphQL: vi.fn(),
+}));
+
+const mockFetchGraphQL = fetchGraphQL as unknown as Mock;
+
+const QUERY = "{ posts { nodes { slug } pageInfo { hasNextPage endCursor } } }";
+
+function makeResponse(
+  entity: "posts" | "pages",
+  slugs: string[],
+  hasNextPage = false,
+  endCursor: string | null = null
+) {
+  return {
+    [entity]: {
+      nodes: slugs.map((slug) => ({ slug })),
+      pageInfo: { hasNextPage, endCursor },
+    },
+  };
+}
+
+describe("fetchAllSlugs", () => {
+  beforeEach(() => {
+    mockFetchGraphQL.mockReset();
+  });
+
+  it("returns slugs from a single page", async () => {
+    mockFetchGraphQL.mockResolvedValueOnce(makeResponse("posts", ["post-a", "post-b"]));
+
+    const result = await fetchAllSlugs("posts", QUERY);
+
+    expect(result).toEqual([{ slug: "post-a" }, { slug: "post-b" }]);
+    expect(mockFetchGraphQL).toHaveBeenCalledTimes(1);
+    expect(mockFetchGraphQL).toHaveBeenCalledWith(QUERY, { first: 100, after: null });
+  });
+
+  it("paginates through multiple pages accumulating all slugs", async () => {
+    mockFetchGraphQL
+      .mockResolvedValueOnce(makeResponse("posts", ["page1-post"], true, "cursor-1"))
+      .mockResolvedValueOnce(makeResponse("posts", ["page2-post"], false, null));
+
+    const result = await fetchAllSlugs("posts", QUERY);
+
+    expect(result).toEqual([{ slug: "page1-post" }, { slug: "page2-post" }]);
+    expect(mockFetchGraphQL).toHaveBeenCalledTimes(2);
+    expect(mockFetchGraphQL).toHaveBeenNthCalledWith(1, QUERY, { first: 100, after: null });
+    expect(mockFetchGraphQL).toHaveBeenNthCalledWith(2, QUERY, { first: 100, after: "cursor-1" });
+  });
+
+  it("works for the 'pages' entity type", async () => {
+    mockFetchGraphQL.mockResolvedValueOnce(makeResponse("pages", ["about", "contact"]));
+
+    const result = await fetchAllSlugs("pages", QUERY);
+
+    expect(result).toEqual([{ slug: "about" }, { slug: "contact" }]);
+  });
+
+  it("returns an empty array when there are no items", async () => {
+    mockFetchGraphQL.mockResolvedValueOnce(makeResponse("posts", []));
+
+    const result = await fetchAllSlugs("posts", QUERY);
+
+    expect(result).toEqual([]);
+  });
+
+  it("logs a warning and skips when nodes is not an array", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    mockFetchGraphQL.mockResolvedValueOnce({
+      posts: {
+        nodes: null,
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    const result = await fetchAllSlugs("posts", QUERY);
+
+    expect(result).toEqual([]);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Warning: items is not an array",
+      null,
+      expect.anything()
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("handles three pages correctly", async () => {
+    mockFetchGraphQL
+      .mockResolvedValueOnce(makeResponse("posts", ["a"], true, "c1"))
+      .mockResolvedValueOnce(makeResponse("posts", ["b"], true, "c2"))
+      .mockResolvedValueOnce(makeResponse("posts", ["c"], false, null));
+
+    const result = await fetchAllSlugs("posts", QUERY);
+
+    expect(result).toEqual([{ slug: "a" }, { slug: "b" }, { slug: "c" }]);
+    expect(mockFetchGraphQL).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/ownerSlug.test.ts
+++ b/src/lib/ownerSlug.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { toOwnerSlug } from "./ownerSlug";
+
+describe("toOwnerSlug", () => {
+  it("lowercases the name", () => {
+    expect(toOwnerSlug("John Smith")).toBe("john-smith");
+  });
+
+  it("replaces & with 'and'", () => {
+    expect(toOwnerSlug("Tom & Jerry")).toBe("tom-and-jerry");
+  });
+
+  it("replaces spaces and punctuation with hyphens", () => {
+    expect(toOwnerSlug("The Bull's Head")).toBe("the-bull-s-head");
+  });
+
+  it("collapses consecutive non-alphanumeric characters into a single hyphen", () => {
+    expect(toOwnerSlug("The   Pub")).toBe("the-pub");
+  });
+
+  it("trims leading and trailing whitespace before slugifying", () => {
+    expect(toOwnerSlug("  Pub  ")).toBe("pub");
+  });
+
+  it("strips leading and trailing hyphens produced by punctuation at the edges", () => {
+    expect(toOwnerSlug("(The Pub)")).toBe("the-pub");
+  });
+
+  it("preserves digits in the output", () => {
+    expect(toOwnerSlug("Pub 42")).toBe("pub-42");
+  });
+
+  it("returns a name that is already slug-friendly unchanged", () => {
+    expect(toOwnerSlug("thepub")).toBe("thepub");
+  });
+
+  it("handles ampersand next to words without spaces", () => {
+    expect(toOwnerSlug("Tom&Jerry")).toBe("tomandjerry");
+  });
+
+  it("returns an empty string for an empty input", () => {
+    expect(toOwnerSlug("")).toBe("");
+  });
+});

--- a/src/lib/yearlyRoastStats.test.ts
+++ b/src/lib/yearlyRoastStats.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Post } from "../types";
+import { buildYearlyRoastStats, fetchAllPosts } from "./yearlyRoastStats";
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    date: "2024-01-01",
+    slug: "test-slug",
+    title: "Test Post",
+    typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+    ratings: { nodes: [{ name: "7" }] },
+    yearsOfVisit: { nodes: [{ name: "2024" }] },
+    ...overrides,
+  } as Post;
+}
+
+function makeFetchGraphQL(pages: Array<{ posts: Post[]; hasNextPage: boolean; endCursor: string | null }>) {
+  const mock = vi.fn();
+  for (const page of pages) {
+    mock.mockResolvedValueOnce({
+      posts: {
+        nodes: page.posts,
+        pageInfo: { hasNextPage: page.hasNextPage, endCursor: page.endCursor },
+      },
+    });
+  }
+  return mock;
+}
+
+describe("fetchAllPosts", () => {
+  it("returns all posts from a single page", async () => {
+    const posts = [makePost({ slug: "a" }), makePost({ slug: "b" })];
+    const fetch = makeFetchGraphQL([{ posts, hasNextPage: false, endCursor: null }]);
+
+    const result = await fetchAllPosts(fetch, "GET_ALL_POSTS");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].slug).toBe("a");
+    expect(result[1].slug).toBe("b");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("GET_ALL_POSTS", {});
+  });
+
+  it("paginates through multiple pages", async () => {
+    const fetch = makeFetchGraphQL([
+      { posts: [makePost({ slug: "page1" })], hasNextPage: true, endCursor: "cursor-1" },
+      { posts: [makePost({ slug: "page2" })], hasNextPage: false, endCursor: null },
+    ]);
+
+    const result = await fetchAllPosts(fetch, "GET_ALL_POSTS");
+
+    expect(result).toHaveLength(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(1, "GET_ALL_POSTS", {});
+    expect(fetch).toHaveBeenNthCalledWith(2, "GET_ALL_POSTS", { after: "cursor-1" });
+  });
+
+  it("returns an empty array when there are no posts", async () => {
+    const fetch = makeFetchGraphQL([{ posts: [], hasNextPage: false, endCursor: null }]);
+
+    const result = await fetchAllPosts(fetch, "GET_ALL_POSTS");
+
+    expect(result).toEqual([]);
+  });
+
+  it("accumulates posts across three pages", async () => {
+    const fetch = makeFetchGraphQL([
+      { posts: [makePost({ slug: "a" })], hasNextPage: true, endCursor: "c1" },
+      { posts: [makePost({ slug: "b" })], hasNextPage: true, endCursor: "c2" },
+      { posts: [makePost({ slug: "c" })], hasNextPage: false, endCursor: null },
+    ]);
+
+    const result = await fetchAllPosts(fetch, "GET_ALL_POSTS");
+
+    expect(result.map((p) => p.slug)).toEqual(["a", "b", "c"]);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("buildYearlyRoastStats", () => {
+  it("counts roast dinner posts grouped by year", () => {
+    const posts = [
+      makePost({ yearsOfVisit: { nodes: [{ name: "2023" }] } }),
+      makePost({ yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+      makePost({ yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, () => false);
+
+    expect(result["2023"]).toEqual({ matching: 0, total: 1 });
+    expect(result["2024"]).toEqual({ matching: 0, total: 2 });
+  });
+
+  it("increments matching count when isMatchingRating returns true", () => {
+    const posts = [
+      makePost({ ratings: { nodes: [{ name: "8" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+      makePost({ ratings: { nodes: [{ name: "6" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, (rating) => rating >= 8);
+
+    expect(result["2024"]).toEqual({ matching: 1, total: 2 });
+  });
+
+  it("ignores posts that are not of type 'Roast Dinner'", () => {
+    const posts = [
+      makePost({ typesOfPost: { nodes: [{ name: "Pub Review" }] } }),
+      makePost({ typesOfPost: { nodes: [{ name: "Roast Dinner" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, () => true);
+
+    expect(Object.keys(result)).toEqual(["2024"]);
+    expect(result["2024"].total).toBe(1);
+  });
+
+  it("ignores posts without a yearsOfVisit entry", () => {
+    const posts = [
+      makePost({ yearsOfVisit: { nodes: [] } }),
+      makePost({ yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, () => true);
+
+    expect(Object.keys(result)).toEqual(["2024"]);
+    expect(result["2024"].total).toBe(1);
+  });
+
+  it("does not increment matching when the rating is NaN", () => {
+    const posts = [
+      makePost({ ratings: { nodes: [] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+      makePost({ ratings: { nodes: [{ name: "not-a-number" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, () => true);
+
+    expect(result["2024"]).toEqual({ matching: 0, total: 2 });
+  });
+
+  it("returns an empty object when given no posts", () => {
+    const result = buildYearlyRoastStats([], () => true);
+
+    expect(result).toEqual({});
+  });
+
+  it("supports a custom isMatchingRating predicate (e.g. rating >= 9)", () => {
+    const posts = [
+      makePost({ ratings: { nodes: [{ name: "9.5" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+      makePost({ ratings: { nodes: [{ name: "8" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+      makePost({ ratings: { nodes: [{ name: "9" }] }, yearsOfVisit: { nodes: [{ name: "2024" }] } }),
+    ];
+
+    const result = buildYearlyRoastStats(posts, (rating) => rating >= 9);
+
+    expect(result["2024"]).toEqual({ matching: 2, total: 3 });
+  });
+});


### PR DESCRIPTION
## Summary

Today is Tuesday — the scheduled category is **Tests**. Analysis of the codebase identified four library modules with no unit-test coverage. This PR adds 38 new tests across four new test files.

### New test files

| File | Module under test | What's covered |
|---|---|---|
| `src/lib/api.test.ts` | `fetchGraphQL` / `resetGraphQLRequestCache` | POST request shape, variable defaults, response parsing, request deduplication (sequential and concurrent), stable cache-key generation regardless of variable key order, cache eviction on GraphQL errors and non-OK HTTP responses so retries can re-attempt, error message content |
| `src/lib/fetchAllSlugs.test.ts` | `fetchAllSlugs` | Single-page results, multi-page pagination with cursor forwarding, three-page accumulation, both `posts` and `pages` entity types, empty result set, `console.warn` branch when `nodes` is not an array |
| `src/lib/ownerSlug.test.ts` | `toOwnerSlug` | Lowercasing, `&` → `and` expansion, space/punctuation → hyphen normalisation, consecutive-separator collapse, leading/trailing hyphen stripping, digit preservation, already-slug-friendly input, empty string |
| `src/lib/yearlyRoastStats.test.ts` | `fetchAllPosts` + `buildYearlyRoastStats` | Single-page and multi-page `fetchAllPosts` pagination with cursor forwarding; `buildYearlyRoastStats` grouping by year, `matching` counter logic, custom `isMatchingRating` predicate, NaN rating skipping, missing `yearsOfVisit` skipping, non-Roast-Dinner post exclusion, empty input |

### What was intentionally skipped

- **`src/lib/kv.ts`** — thin Vercel KV client initialisation with no testable logic
- **GraphQL query files** (`src/lib/queries/*.ts`) — pure string constants with nothing to assert
- **`useSortFilter` hook** — already thoroughly exercised by the existing `sort-posts.test.tsx` integration tests (all seven `translateClosedDown` cases, all filter and sort branches, column toggles)

## Test plan

- [x] All 38 new tests pass: `vitest run src/lib/api.test.ts src/lib/fetchAllSlugs.test.ts src/lib/ownerSlug.test.ts src/lib/yearlyRoastStats.test.ts`
- [x] Full suite continues to pass: 91 test files, 262 tests, 0 failures

https://claude.ai/code/session_014AQAfn9Yx8cMzZ2a8okgsY