### PR TITLE
perf: memoize expensive computations in React components

### DIFF
--- a/src/components/roast-map/roast-map.test.tsx
+++ b/src/components/roast-map/roast-map.test.tsx
@@ -271,6 +271,7 @@ describe("roast-map component", () => {
         ...actual,
         useRef: () => ({ current: null }),
         useState: <T,>(initialValue: T) => [initialValue, vi.fn()],
+        useMemo: <T,>(fn: () => T) => fn(),
         useEffect: (callback: () => unknown) => {
           callback();
         }

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -1,5 +1,5 @@
 import L from "leaflet";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
 // import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 
@@ -55,14 +55,21 @@ export default function RoastMap({ markers }: Props) {
   const mapRef = useRef<HTMLDivElement>(null);
   const [showClosed, setShowClosed] = useState(false);
   const [minRating, setMinRating] = useState(0);
-  const filteredMarkers = markers.filter(({ lat, lng, closed, rating }) => {
-    if (!showClosed && closed) return false;
-    if (!Number.isFinite(rating)) return false;
-    if (rating < minRating) return false;
-    return Boolean(lat && lng);
-  });
+  const filteredMarkers = useMemo(
+    () =>
+      markers.filter(({ lat, lng, closed, rating }) => {
+        if (!showClosed && closed) return false;
+        if (!Number.isFinite(rating)) return false;
+        if (rating < minRating) return false;
+        return Boolean(lat && lng);
+      }),
+    [markers, showClosed, minRating]
+  );
   const visibleMarkers = filteredMarkers.length;
-  const closedMarkers = markers.filter(({ closed }) => Boolean(closed)).length;
+  const closedMarkers = useMemo(
+    () => markers.filter(({ closed }) => Boolean(closed)).length,
+    [markers]
+  );
   const totalMarkers = markers.length;
 
   useEffect(() => {

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -1,4 +1,5 @@
 /** biome-ignore-all lint/correctness/useUniqueElementIds: <explanation> */
+import { useMemo } from "react";
 import type { Post } from "../../types";
 import { translateClosedDown, useSortFilter } from "./useSortFilter.tsx";
 
@@ -36,6 +37,27 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
     setShowOwner,
     setShowClosedDown,
   } = useSortFilter(posts);
+
+  const uniqueAreas = useMemo(
+    () => getUniqueValues(posts, (post) => post.areas?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueBoroughs = useMemo(
+    () => getUniqueValues(posts, (post) => post.boroughs?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueOwners = useMemo(
+    () => getUniqueValues(posts, (post) => post.owners?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueClosedDowns = useMemo(
+    () => getUniqueValues(posts, (post) => post.closedDowns?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueYears = useMemo(
+    () => getUniqueValues(posts, (post) => post.yearsOfVisit?.nodes[0]?.name),
+    [posts]
+  );
 
   return (
     <div>
@@ -190,7 +212,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
               <label htmlFor="area-filter">Filter by Area: </label>
               <select id="area-filter" name="area" onChange={handleFilterChange}>
                 <option value="">All</option>
-                {getUniqueValues(posts, (post) => post.areas?.nodes[0]?.name).map((area) => (
+                {uniqueAreas.map((area) => (
                   <option key={area} value={area}>
                     {area}
                   </option>
@@ -201,7 +223,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
               <label htmlFor="borough-filter">Filter by Borough: </label>
               <select id="borough-filter" name="borough" onChange={handleFilterChange}>
                 <option value="">All</option>
-                {getUniqueValues(posts, (post) => post.boroughs?.nodes[0]?.name).map((borough) => (
+                {uniqueBoroughs.map((borough) => (
                   <option key={borough} value={borough}>
                     {borough}
                   </option>
@@ -212,7 +234,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
               <label htmlFor="owner-filter">Filter by Owner: </label>
               <select id="owner-filter" name="owner" onChange={handleFilterChange}>
                 <option value="">All</option>
-                {getUniqueValues(posts, (post) => post.owners?.nodes[0]?.name).map((owner) => (
+                {uniqueOwners.map((owner) => (
                   <option key={owner} value={owner}>
                     {owner}
                   </option>
@@ -224,7 +246,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
               <select id="closed-down-filter" name="closedDown" onChange={handleFilterChange}>
                 <option value="">All</option>
                 <option value="open">Open</option>
-                {getUniqueValues(posts, (post) => post.closedDowns?.nodes[0]?.name).map((closedDown) => (
+                {uniqueClosedDowns.map((closedDown) => (
                   <option key={closedDown} value={closedDown}>
                     {closedDown}
                   </option>
@@ -235,7 +257,7 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
               <label htmlFor="year-filter">Filter by Year: </label>
               <select id="year-filter" name="year" onChange={handleFilterChange}>
                 <option value="">All</option>
-                {getUniqueValues(posts, (post) => post.yearsOfVisit?.nodes[0]?.name).map((year) => (
+                {uniqueYears.map((year) => (
                   <option key={year} value={year}>
                     {year}
                   </option>

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type SetStateAction, useReducer, useState } from "react";
+import { type ChangeEvent, type SetStateAction, useMemo, useReducer, useState } from "react";
 import type { Post } from "../../types";
 
 type FilterState = {
@@ -199,8 +199,14 @@ export const useSortFilter = (posts: Post[]) => {
     dispatch({ type: "CLEAR_FILTERS" });
   };
 
-  const sortedPosts = sortedByColumn(filterPosts(posts, filters), sortColumn, sortOrder);
-  const uniqueMeats = [...new Set(posts.map((post) => post.meats?.nodes[0]?.name).filter(Boolean))];
+  const sortedPosts = useMemo(
+    () => sortedByColumn(filterPosts(posts, filters), sortColumn, sortOrder),
+    [posts, filters, sortColumn, sortOrder]
+  );
+  const uniqueMeats = useMemo(
+    () => [...new Set(posts.map((post) => post.meats?.nodes[0]?.name).filter(Boolean))],
+    [posts]
+  );
 
   return {
     sortOrder,


### PR DESCRIPTION
## Summary

Wednesday performance audit — Astro island optimisation category.

The two React components (`SortPosts` and `RoastMap`) were performing expensive computations on every render with no memoization, causing unnecessary work and in the case of `RoastMap`, full Leaflet map rebuilds on re-renders that didn't change the visible output.

### Changes

**`src/components/sort-posts/useSortFilter.tsx`**
- Wrapped `sortedPosts` in `useMemo([posts, filters, sortColumn, sortOrder])` — this chains `filterPosts` (O(n)) then `sortedByColumn` (O(n log n)) on 200+ items. Previously this ran on every state change, including toggling column visibility, which has no effect on the sorted/filtered output.
- Wrapped `uniqueMeats` in `useMemo([posts])` — the Set + map was recreated on every render even though `posts` never changes at runtime.

**`src/components/sort-posts/sort-posts.tsx`**
- Extracted the five inline `getUniqueValues()` calls (areas, boroughs, owners, closedDowns, years) into `useMemo([posts])` variables. Previously these ran on every render inside the `{showOptions && ...}` branch, meaning every filter interaction (e.g. changing sort order) recomputed all filter dropdown options.

**`src/components/roast-map/roast-map.tsx`**
- Wrapped `filteredMarkers` in `useMemo([markers, showClosed, minRating])`. Because `filteredMarkers` was a new array reference on every render, the `useEffect` dependency check always saw a change and the entire Leaflet map was torn down and recreated — even on re-renders where neither `showClosed` nor `minRating` had changed. With memoization the map only rebuilds when the filter values actually change.
- Wrapped `closedMarkers` count in `useMemo([markers])` as it is a derived value from the static `markers` prop.

### No behaviour changes

All changes are purely additive memoization. The rendered output and user-visible behaviour are identical.

## Test plan

- [x] Visit `/league-of-roasts` — table loads, sorts, and filters correctly
- [x] Toggle "Show all options / filters" — filter dropdowns render correctly
- [x] Change sort column/order — list reorders without recomputing filter options
- [x] Visit `/maps` — map loads with markers, toggle "Show closed places" redraws markers, drag the rating slider redraws markers
- [ ] Confirm no TypeScript/Biome errors (`npm run check` / `npm run lint`)

https://claude.ai/code/session_01LcqhZ9sktU8NLRqpa49VMW