### PR TITLE
fix(a11y/seo): Accessibility & SEO improvements — Thursday 2026-04-16

### DIFF
--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -36,11 +36,11 @@ if (tag) {
       <ul>
         {locationPosts.map((post) => (
           <li class="heading">
-            <h3>
+            <h4>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
                 <Fragment set:html={post?.title} />
               </a>
-            </h3>
+            </h4>
             <a href={`/${post?.slug}`} rel="noopener noreferrer">
               <img
                 src={post?.featuredImageUrl}

--- a/src/components/search/search.astro
+++ b/src/components/search/search.astro
@@ -20,33 +20,35 @@ const { resultLimit = 4 } = Astro.props;
     <button type="submit">Search</button>
   </form>
 
-  <section class="home-list search-container" aria-label="Search results" x-show="searchResults.length > 0">
-    <ul>
-      <template x-for="post in searchResults" :key="post.slug">
-        <li class="heading">
-          <h3>
-            <a :href="`/${post.slug}`" x-text="post.title"></a>
-          </h3>
+  <div aria-live="polite" aria-atomic="false">
+    <section class="home-list search-container" aria-label="Search results" x-show="searchResults.length > 0">
+      <ul>
+        <template x-for="post in searchResults" :key="post.slug">
+          <li class="heading">
+            <h3>
+              <a :href="`/${post.slug}`" x-text="post.title"></a>
+            </h3>
 
-          <a
-            :href="`/${post.slug}`"
-            rel="noopener noreferrer"
-            class="featured-image"
-          >
-            <img
-              :src="post.featuredImage?.node?.sourceUrl"
-              :alt="`Photo of the roast dinner at ${post.title}`"
-              width="400"
-              height="300"
-            />
-          </a>
-        </li>
-      </template>
-    </ul>
-  </section>
-  <p x-show="searchPerformed && searchResults.length === 0">
-    No results found.
-  </p>
+            <a
+              :href="`/${post.slug}`"
+              rel="noopener noreferrer"
+              class="featured-image"
+            >
+              <img
+                :src="post.featuredImage?.node?.sourceUrl"
+                :alt="`Photo of the roast dinner at ${post.title}`"
+                width="400"
+                height="300"
+              />
+            </a>
+          </li>
+        </template>
+      </ul>
+    </section>
+    <p x-show="searchPerformed && searchResults.length === 0">
+      No results found.
+    </p>
+  </div>
 </div>
 
 <script is:inline>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -73,6 +73,14 @@ const canonicalURL = Astro.site
           siteName: "Roast Dinners In London",
         },
       }}
+      twitter={{
+        card: "summary_large_image",
+        title: pageTitle || "Roast Dinners In London",
+        description:
+          description ||
+          "Lord Gravy bringing you a guide to the best and worst roast dinners in London.",
+        image: opengraphImage || logo1.src,
+      }}
     />
     {
       structuredData && (

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -127,6 +127,41 @@ const featuredImageUrl = singlePost.featuredImage?.node?.sourceUrl || logo3;
 const threadedComments = organiseComments(
   contentType === "page" ? data.page.comments.nodes : data.post.comments.nodes
 );
+
+const reviewStructuredData =
+  contentType === "post" && isRoastDinner
+    ? {
+        "@context": "https://schema.org",
+        "@type": "Review",
+        itemReviewed: {
+          "@type": "Restaurant",
+          name: singlePost.title,
+        },
+        author: {
+          "@type": "Person",
+          name: "Lord Gravy",
+        },
+        ...(rating
+          ? {
+              reviewRating: {
+                "@type": "Rating",
+                ratingValue: rating,
+                bestRating: "10",
+                worstRating: "0",
+              },
+            }
+          : {}),
+        datePublished: singlePost.date,
+        ...(singlePost?.seo?.opengraphDescription
+          ? { description: singlePost.seo.opengraphDescription }
+          : {}),
+        publisher: {
+          "@type": "Organization",
+          name: "Roast Dinners In London",
+          url: Astro.site?.toString() ?? "https://rdldn.co.uk",
+        },
+      }
+    : undefined;
 ---
 
 <BaseLayout
@@ -134,6 +169,7 @@ const threadedComments = organiseComments(
   description={singlePost?.seo?.opengraphDescription}
   opengraphImage={singlePost.seo?.opengraphImage?.sourceUrl}
   halloween={singlePost.typesOfPost?.nodes?.some((node: { name: string }) => node.name === "Halloween") ? true : false}
+  structuredData={reviewStructuredData}
 >
   <FeaturedPostHeader imageSrc={featuredImageUrl} title={singlePost.title}>
     {singlePost.closedDowns?.nodes?.length > 0 && (
@@ -161,6 +197,8 @@ const threadedComments = organiseComments(
             if (el) {
               const y = el.getBoundingClientRect().top + window.pageYOffset - 120;
               window.scrollTo({ top: y, behavior: 'smooth' });
+              el.setAttribute('tabindex', '-1');
+              el.focus({ preventScroll: true });
             }
           "
         >

--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -61,7 +61,7 @@ const roastListStructuredData = {
     "@type": "ListItem",
     position: idx + 1,
     name: post.title,
-    url: post.slug ? `https://roastdinners.london/${post.slug}` : undefined,
+    url: post.slug && Astro.site ? new URL(post.slug, Astro.site).href : undefined,
   })),
 };
 ---


### PR DESCRIPTION
## Summary

Thursday focus: **Accessibility & SEO**. Six targeted, safe fixes across five files.

### Changes

**`src/layouts/BaseLayout.astro` — Twitter Card meta tags**
The site had OpenGraph tags but no `twitter:` meta tags. Many platforms (Slack, LinkedIn, iMessage, Discord) use `twitter:card` even when sharing outside of Twitter/X. Added `summary_large_image` card type with title, description, and image — reusing the same values already set for OpenGraph, so no per-page changes are needed.

**`src/components/roastByTagSection/roast-by-tag-section.astro` — Heading hierarchy fix**
The "Roasts in {tag}" section had an `<h3>` as the section heading and _also_ `<h3>` for each individual post title inside the list. Both at the same level creates a confusing/invalid heading tree for screen readers and SEO crawlers. Individual post titles changed to `<h4>`.

**`src/pages/league-of-roasts.astro` — Fix hardcoded domain in structured data**
The `ItemList` JSON-LD was building URLs with `https://roastdinners.london/` — an old/wrong domain. Changed to derive URLs from `Astro.site` (configured as `https://rdldn.co.uk` in `astro.config.mjs`) using `new URL(slug, Astro.site).href`, so the structured data stays correct if the domain ever changes.

**`src/components/search/search.astro` — ARIA live region for search results**
The search results section appeared/disappeared via Alpine `x-show`, but screen readers had no signal that new content had arrived. Wrapped both the results section and the "No results found" message in `<div aria-live="polite">` so assistive technology announces updates after each search.

**`src/pages/[slug].astro` — `schema.org/Review` structured data + skip-link focus**

- Added `Review` structured data for roast dinner posts (guarded by `isRoastDinner`). Includes `itemReviewed` (Restaurant name), `author` (Lord Gravy), `reviewRating` (ratingValue out of 10), `datePublished`, and `publisher`. This enables rich snippet eligibility in Google Search for review pages.
- Fixed the "Skip The Nonsense" button: previously it scrolled to `#summary` but left keyboard focus where it was, meaning keyboard-only users still had to tab through all preceding content. Now sets `tabindex="-1"` on the target element and calls `el.focus({ preventScroll: true })` so focus moves with the scroll.

## Test plan

- [x] Build passes (`astro build`) — no TypeScript errors from new structured data shape
- [x] View source on any roast dinner post page — confirm `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` meta tags are present
- [ ] Paste a roast dinner URL into a Twitter/X Card Validator or Opengraph.xyz — rich card renders
- [ ] On a page that uses `roast-by-tag-section` (e.g. any individual roast post) — inspect heading hierarchy, post titles should be `<h4>` not `<h3>`
- [ ] View source on League of Roasts page — `ItemList` JSON-LD URLs should be `https://rdldn.co.uk/…` not `https://roastdinners.london/…`
- [ ] On a roast dinner post page — view source, confirm `Review` JSON-LD is present with correct restaurant name and rating
- [ ] On a roast dinner post page — use keyboard only, press Tab to reach "Skip The Nonsense", press Enter, confirm focus lands on the Summary section
- [ ] Run search on homepage or search page — use a screen reader or browser accessibility inspector to confirm results are announced after searching

https://claude.ai/code/session_019zGxMmXBSF5box7siNYG22