### PR TITLE
feat: add Best Value Roast Dinners in London page

### DIFF
--- a/src/pages/best-value-roast-dinners-in-london.astro
+++ b/src/pages/best-value-roast-dinners-in-london.astro
@@ -1,0 +1,183 @@
+---
+import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
+import Newsletter from "../components/newsletter/newsletter.astro";
+import logo3 from "../images/logo-3.png";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { fetchGraphQL } from "../lib/api";
+import GET_ALL_POSTS from "../lib/queries/getAllPosts";
+import { fetchAllPosts } from "../lib/yearlyRoastStats";
+import type { Post } from "../types";
+import "../styles/post.css";
+
+export const prerender = true;
+
+const PAGE_TITLE = "Best Value Roast Dinners in London";
+const PAGE_DESCRIPTION =
+  "Which London restaurants give you the best roast dinner for your money? We rank every reviewed restaurant by value score: rating per £ spent.";
+
+const allPosts = await fetchAllPosts(fetchGraphQL, GET_ALL_POSTS);
+
+const roastPosts = allPosts.filter((post: Post) =>
+  post.typesOfPost?.nodes.some((type) => type.name === "Roast Dinner")
+);
+
+interface ValuePost {
+  title: string;
+  slug: string;
+  rating: number;
+  price: number;
+  valueScore: number;
+}
+
+const valuePosts: ValuePost[] = roastPosts
+  .filter((post) => !post.closedDowns?.nodes[0]?.name)
+  .reduce<ValuePost[]>((acc, post) => {
+    const ratingStr = post.ratings?.nodes[0]?.name;
+    const priceStr = post.prices?.nodes[0]?.name;
+    const title = post.title;
+    const slug = post.slug;
+
+    if (!ratingStr || !priceStr || !title || !slug) return acc;
+
+    const ratingMatch = ratingStr.match(/[\d.]+/);
+    const priceMatch = priceStr.match(/[\d,.]+/);
+
+    if (!ratingMatch || !priceMatch) return acc;
+
+    const rating = Number.parseFloat(ratingMatch[0]);
+    const price = Number.parseFloat(priceMatch[0].replace(/,/g, ""));
+
+    if (Number.isNaN(rating) || Number.isNaN(price) || price <= 0 || rating <= 0)
+      return acc;
+
+    acc.push({
+      title,
+      slug,
+      rating,
+      price,
+      valueScore: Number.parseFloat(((rating / price) * 10).toFixed(2)),
+    });
+
+    return acc;
+  }, [])
+  .sort((a, b) => b.valueScore - a.valueScore)
+  .slice(0, 30);
+---
+
+<BaseLayout pageTitle={PAGE_TITLE} description={PAGE_DESCRIPTION}>
+  <FeaturedPostHeader imageSrc={logo3.src} title={PAGE_TITLE} />
+  <div class="container">
+    <p>
+      A high rating doesn't always mean great value. A place charging £25 for a
+      <strong>9/10</strong> roast isn't necessarily better value than somewhere charging
+      £14 for an <strong>8/10</strong>. To find out which restaurants truly deliver
+      the most for your money, we've calculated a <strong>value score</strong> for
+      every reviewed restaurant that's still open.
+    </p>
+    <p>
+      <strong>How it works:</strong> value score = (rating ÷ price) × 10. The higher
+      the score, the more rating-per-pound you get. Only open restaurants with both
+      a rating and a price are included.
+    </p>
+
+    {
+      valuePosts.length > 0 ? (
+        <div class="value-table-wrapper">
+          <table class="value-table">
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Restaurant</th>
+                <th scope="col">Rating</th>
+                <th scope="col">Price</th>
+                <th scope="col">Value Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {valuePosts.map((post, index) => (
+                <tr>
+                  <td>{index + 1}</td>
+                  <td>
+                    <a href={`/${post.slug}`}>{post.title}</a>
+                  </td>
+                  <td>{post.rating.toFixed(1)}</td>
+                  <td>£{post.price.toFixed(2)}</td>
+                  <td class="value-score">{post.valueScore.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p>No value data available at the moment.</p>
+      )
+    }
+
+    <p>
+      <em>
+        Prices are from the time of the review and may have changed. Value score =
+        (rating ÷ price) × 10. Only open restaurants are included. Minimum rating
+        of 0.1 required.
+      </em>
+    </p>
+
+    <Newsletter />
+  </div>
+</BaseLayout>
+
+<style>
+  .value-table-wrapper {
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+
+  .value-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+
+  .value-table th,
+  .value-table td {
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  .value-table thead th {
+    background-color: var(--roast-new-blue);
+    color: white;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .value-table tbody tr:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+
+  .value-table tbody tr:hover {
+    background-color: #f0f4ff;
+  }
+
+  .value-table td:first-child {
+    color: #666;
+    font-size: 0.85rem;
+    width: 2.5rem;
+    white-space: nowrap;
+  }
+
+  .value-table td a {
+    color: var(--roast-new-blue);
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .value-table td a:hover {
+    text-decoration: underline;
+  }
+
+  .value-score {
+    font-weight: 700;
+    color: #1a7a1a;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds a new page `/best-value-roast-dinners-in-london` that ranks every open, reviewed restaurant by a **value score**: `(rating ÷ price) × 10`
- This answers a question no existing page addressed: *"where gets you the most for your money?"*
- Displays the top 30 results in a responsive, branded table with links to each individual review
- Includes a clear methodology explanation and newsletter CTA
- Prerendered at build time — no new runtime dependencies, no new packages

## Why this feature?

The site already has pages for highest-rated places and cheapest boroughs, but nothing that combines both dimensions into a single, actionable ranking. A 9/10 roast at £28 has a value score of **3.21**; an 8/10 roast at £14 scores **5.71** — clearly better value. This page makes that comparison explicit and easy to share.

It targets a real search intent ("best value roast dinner London") and gives visitors a new reason to visit and share.

## Implementation notes

- Follows the same data-fetching patterns as `which-borough-of-london-has-the-cheapest-roast-dinners.astro` and `annual-roastatistics.astro`
- Uses the existing `fetchAllPosts` helper from `lib/yearlyRoastStats.ts`
- Filters out closed restaurants and posts missing rating or price data
- Uses `logo3.png` for the header image (same fallback as league-of-roasts)
- Passes `biome check` with no errors

## Test plan

- [ ] Visit `/best-value-roast-dinners-in-london` on the built site and verify the table renders with 30 rows
- [ ] Confirm each restaurant name links to its individual review page
- [ ] Confirm value scores are sorted highest-first
- [ ] Confirm closed-down restaurants are excluded
- [ ] Check the page looks reasonable on mobile (table is horizontally scrollable)

https://claude.ai/code/session_01TejoS7AvSCtHB3GmGgusmz