### PR TITLE
fix(a11y): SVG map marker titles, orange contrast, and aria-controls

### DIFF
--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -35,7 +35,8 @@ const createColouredIcon = (colour: string, backgroundColour: string, value: num
   return L.divIcon({
     className: "",
     html: `
-      <svg width="32" height="48" viewBox="0 0 32 48" xmlns="http://www.w3.org/2000/svg">
+      <svg width="32" height="48" viewBox="0 0 32 48" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Rating: ${formattedValue} out of 10">
+        <title>Rating: ${formattedValue} out of 10</title>
         <path d="
           M16 47
           C16 47, 14 36, 8 24

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -70,11 +70,12 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
         className="show-hide-button"
         onClick={() => setShowOptions((prev) => !prev)}
         aria-expanded={showOptions}
+        aria-controls="sort-options-panel"
       >
         {showOptions ? "Hide options" : "Show all options / filters"}
       </button>
       {showOptions && (
-        <div>
+        <div id="sort-options-panel">
           <div className="toggle-columns">
             <h3>Show/hide columns:</h3>
             <div>

--- a/src/pages/guessthescore/game.css
+++ b/src/pages/guessthescore/game.css
@@ -157,7 +157,7 @@
   }
 
   &.okay {
-    background: #b76e00;
+    background: #7a4b00;
   }
 
   &.bad {


### PR DESCRIPTION
- Add <title> and aria-label to SVG map markers in roast-map
- Darken okay badge from #b76e00 to #7a4b00 (6.7:1 contrast vs white, WCAG AA)
- Add aria-controls and id to sort-posts toggle button/panel