### PR TITLE
chore: add Vercel cron job to keep Upstash Redis database active

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "crons": [
+    {
+      "path": "/guessthescore/api/scores",
+      "schedule": "0 9 * * 1"
+    }
+  ],
   "headers": [
     {
       "source": "/~partytown/(.*)",


### PR DESCRIPTION
Pings the leaderboard scores endpoint weekly (Monday 9am) to prevent the free-tier Upstash database from being archived due to inactivity.