### PR TITLE
chore(tests): add tests for middleware and TubeLinePageLayout

### DIFF
--- a/src/layouts/TubeLinePageLayout.test.ts
+++ b/src/layouts/TubeLinePageLayout.test.ts
@@ -1,0 +1,196 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, test, vi } from "vitest";
+import type { Page, Post } from "../types";
+
+vi.mock("astro:assets", () => ({
+	Image: Object.assign(
+		(_result: unknown, props: { src: string; alt?: string }) =>
+			`<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+		{ isAstroComponentFactory: true }
+	),
+}));
+
+const makePage = (overrides: Partial<Page> = {}): Page => ({
+	id: "page-1",
+	pageId: "1",
+	title: "Central Line",
+	slug: "central-line",
+	content: "<p>Central line content</p>",
+	featuredImage: { node: { sourceUrl: "https://example.com/image.jpg" } },
+	featuredImageUrl: "https://example.com/image.jpg",
+	comments: { nodes: [] },
+	...overrides,
+});
+
+const makePost = (title: string, slug: string, tubeStation: string, rating = "7.5"): Post => ({
+	date: "2024-01-01",
+	title,
+	slug,
+	ratings: { nodes: [{ name: rating }] },
+	tubeStations: { nodes: [{ name: tubeStation }] },
+});
+
+describe("TubeLinePageLayout", () => {
+	test("renders line name in the section heading", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage({ title: "Central Line" }),
+				lineName: "Central",
+				headingClass: "central-heading",
+				stations: ["Bank"],
+				roastPosts: [],
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain("Roast Dinners On The Central Line");
+		expect(html).toContain("Where can you find good roast dinners on the Central Line?");
+	});
+
+	test("renders all station names in the list", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Central",
+				headingClass: "central-heading",
+				stations: ["Bank", "Liverpool Street", "Bethnal Green"],
+				roastPosts: [],
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain("Bank");
+		expect(html).toContain("Liverpool Street");
+		expect(html).toContain("Bethnal Green");
+	});
+
+	test("shows a linked post and its rating for a station with a matching post", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const posts = [makePost("The Bank Tavern", "the-bank-tavern", "Bank", "8.5")];
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Central",
+				headingClass: "central-heading",
+				stations: ["Bank", "Liverpool Street"],
+				roastPosts: posts,
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain('href="/the-bank-tavern"');
+		expect(html).toContain("The Bank Tavern");
+		expect(html).toContain("8.5");
+	});
+
+	test("shows no post link for a station with no matching post", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const posts = [makePost("The Bank Tavern", "the-bank-tavern", "Bank")];
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Central",
+				headingClass: "central-heading",
+				stations: ["Bank", "Liverpool Street"],
+				roastPosts: posts,
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain('href="/the-bank-tavern"');
+		// Liverpool Street has no matching post, so no link for it
+		expect(html).not.toContain("href=\"/liverpool-street");
+	});
+
+	test("applies headingClass to the section heading", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Victoria",
+				headingClass: "victoria-blue",
+				stations: ["Brixton"],
+				roastPosts: [],
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain('class="heading-underline victoria-blue"');
+	});
+
+	test("only shows the first matching post per station", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		// roastPosts are already ordered; first in array is the top post
+		const posts = [
+			makePost("Top Pub at Bank", "top-pub-bank", "Bank", "9.0"),
+			makePost("Second Pub at Bank", "second-pub-bank", "Bank", "7.0"),
+		];
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Central",
+				headingClass: "central",
+				stations: ["Bank"],
+				roastPosts: posts,
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain("Top Pub at Bank");
+		expect(html).not.toContain("Second Pub at Bank");
+	});
+
+	test("renders tube connector with invisible class for first and last stations", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage(),
+				lineName: "Central",
+				headingClass: "central",
+				stations: ["Bank", "Liverpool Street", "Bethnal Green"],
+				roastPosts: [],
+				threadedComments: [],
+			},
+		});
+
+		// Both first and last stations have an invisible connector
+		expect(html).toContain('class="tube-connector invisible"');
+	});
+
+	test("renders page title from singlePage prop", async () => {
+		const container = await AstroContainer.create();
+		const { default: Layout } = await import("./TubeLinePageLayout.astro");
+
+		const html = await container.renderToString(Layout, {
+			props: {
+				singlePage: makePage({ title: "Jubilee Line Guide" }),
+				lineName: "Jubilee",
+				headingClass: "jubilee-grey",
+				stations: ["Westminster"],
+				roastPosts: [],
+				threadedComments: [],
+			},
+		});
+
+		expect(html).toContain("Jubilee Line Guide");
+	});
+});

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { middleware } from "../middleware.js";
+
+const makeRequest = (userAgent: string): Request =>
+	new Request("http://localhost/", {
+		headers: { "user-agent": userAgent },
+	});
+
+describe("middleware", () => {
+	test.each([
+		["Bytespider", "Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)"],
+		["AhrefsBot", "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)"],
+		["SemrushBot", "Mozilla/5.0 (compatible; SemrushBot-SA/0.97; +http://www.semrush.com/bot.html)"],
+		["MJ12bot", "Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)"],
+		["dotbot", "Mozilla/5.0 (compatible; dotbot/1.0; http://www.opensiteexplorer.org/dotbot)"],
+		["PetalBot", "Mozilla/5.0 (compatible; PetalBot; +https://aspiegel.com/petalbot)"],
+		["Crawlers", "Mozilla/5.0 (compatible; Crawlers/1.0)"],
+		["Python-requests", "Python-requests/2.28.0"],
+	])("blocks %s user agent with 403", async (_botName, userAgent) => {
+		const response = middleware(makeRequest(userAgent));
+		expect(response).toBeInstanceOf(Response);
+		expect(response?.status).toBe(403);
+		const text = await response!.text();
+		expect(text).toBe("Blocked");
+	});
+
+	test.each([
+		["Chrome browser", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"],
+		["Googlebot", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"],
+		["curl", "curl/7.68.0"],
+		["empty string", ""],
+	])("allows %s user agent", (_label, userAgent) => {
+		const response = middleware(makeRequest(userAgent));
+		expect(response).toBeUndefined();
+	});
+
+	test("blocks when bot string appears in the middle of a user agent", () => {
+		const response = middleware(makeRequest("Custom AhrefsBot 2.0 spider"));
+		expect(response?.status).toBe(403);
+	});
+});


### PR DESCRIPTION
## Summary

Today is Tuesday, so the focus is **Tests**. Two source files had zero test coverage; this PR adds meaningful tests for both.

### What was added

**`src/middleware.test.ts`** (13 tests)

The bot-blocking middleware (`middleware.js`) is an untested Vercel edge function that guards the site from known scrapers. Tests cover:
- Each of the 8 blocked bot strings (`Bytespider`, `AhrefsBot`, `SemrushBot`, `MJ12bot`, `dotbot`, `PetalBot`, `Crawlers`, `Python-requests`) returns a 403 with body `"Blocked"`
- Legitimate user agents (Chrome, Googlebot, curl, empty string) are passed through (`undefined` return)
- A bot string appearing in the middle of a longer UA string is correctly caught

Note: the middleware's `Python-requests` entry uses a capital P, so it only blocks exactly `Python-requests/x.y` — the real `python-requests` library sends a lowercase UA and is not currently blocked. The tests document the actual behaviour rather than assume an intent; a separate fix could normalise the UA to lowercase before checking.

**`src/layouts/TubeLinePageLayout.test.ts`** (8 tests)

`TubeLinePageLayout.astro` had no coverage despite containing non-trivial template logic. Tests cover:
- Line name appears in section heading and paragraph text
- All station names render in the list
- A station with a matching post shows a linked title and its rating
- A station with no matching post shows no link
- `headingClass` prop is applied to the heading element
- Only the first post per station is shown (the `topPost = postsForStation[0]` branch)
- Invisible tube connector classes are rendered for first/last stations

## Test plan
- [x] `vitest run src/middleware.test.ts` — 13/13 pass
- [x] `vitest run src/layouts/TubeLinePageLayout.test.ts` — 8/8 pass
- [x] Full `vitest run` — 283/283 tests across 93 files, all green

https://claude.ai/code/session_01XxEAswwZZQqtvEqWetAjnr