### PR TITLE
fix(a11y/seo): accessibility and SEO improvements

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "Roast Dinners In London",
+  "short_name": "RDLDN",
   "icons": [
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import logo1 from "../images/logo-1.png";
 
 // import logo3 from "/images/logo-3.png";
 
-const { pageTitle, description, opengraphImage, halloween, structuredData } =
+const { pageTitle, description, opengraphImage, halloween, structuredData, ogType = "website" } =
   Astro.props;
 
 const canonicalURL = Astro.site
@@ -54,7 +54,7 @@ const canonicalURL = Astro.site
       openGraph={{
         basic: {
           title: pageTitle || "Roast Dinners In London",
-          type: "Article",
+          type: ogType,
           image: opengraphImage || logo1,
         },
         optional: {
@@ -106,9 +106,10 @@ const canonicalURL = Astro.site
     </script>
   </head>
   <body>
+    <a href="#main-content" class="skip-to-main">Skip to main content</a>
     <div class={`page-container` + (halloween ? " halloween" : "")}>
       <Header />
-      <main>
+      <main id="main-content">
         <slot />
       </main>
       <Footer />

--- a/src/layouts/BestRoastLayout.astro
+++ b/src/layouts/BestRoastLayout.astro
@@ -68,6 +68,9 @@ const {
                 alt={
                   post.featuredImage.node.altText || `Image for ${post.title}`
                 }
+                width="400"
+                height="300"
+                loading="lazy"
               />
             </div>
           )}

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -233,6 +233,23 @@ section {
   border: 0;
 }
 
+.skip-to-main {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 9999;
+  padding: 0.75rem 1.5rem;
+  background: var(--roast-new-blue);
+  color: var(--roast-white);
+  font-weight: bold;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+
+  &:focus {
+    top: 0;
+  }
+}
+
 .substack-signup {
   padding: 1rem;
   text-align: center;

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -170,6 +170,7 @@ const reviewStructuredData =
   opengraphImage={singlePost.seo?.opengraphImage?.sourceUrl}
   halloween={singlePost.typesOfPost?.nodes?.some((node: { name: string }) => node.name === "Halloween") ? true : false}
   structuredData={reviewStructuredData}
+  ogType={contentType === "post" ? "article" : "website"}
 >
   <FeaturedPostHeader imageSrc={featuredImageUrl} title={singlePost.title}>
     {singlePost.closedDowns?.nodes?.length > 0 && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -245,7 +245,7 @@ try {
 <BaseLayout
   pageTitle="Home of Roast Dinners In London"
   description="Lord Gravy bringing you a guide to the best and worst roast dinners in London."
-  openGraphImage={recentPost?.seo?.opengraphImage?.sourceUrl}
+  opengraphImage={recentPost?.seo?.opengraphImage?.sourceUrl}
 >
   <section class="home-list">
     <h2>Latest Reviews:</h2>
@@ -290,7 +290,7 @@ try {
             <a href={page?.slug} rel="noopener noreferrer">
               <img
                 src={page?.featuredImageUrl}
-                alt={`Photo of the roast dinner at ${page?.title}`}
+                alt={`Preview image for ${page?.title}`}
                 width={400}
                 height={300}
                 loading="lazy"
@@ -315,7 +315,7 @@ try {
             <a href={page?.slug} rel="noopener noreferrer">
               <img
                 src={page?.featuredImageUrl}
-                alt={`Photo of the roast dinner at ${page?.title}`}
+                alt={`Preview image for ${page?.title}`}
                 width={400}
                 height={300}
                 loading="lazy"
@@ -409,7 +409,7 @@ try {
             >
               <img
                 src={post?.featuredImageUrl}
-                alt={`Photo of the roast dinner at ${post?.title}`}
+                alt={`Preview image for ${post?.title}`}
                 width="400"
                 height="300"
                 loading={index === 0 ? "eager" : "lazy"}
@@ -438,7 +438,7 @@ try {
             >
               <img
                 src={post?.featuredImageUrl}
-                alt={`Photo of the roast dinner at ${post?.title}`}
+                alt={`Preview image for ${post?.title}`}
                 width="400"
                 height="300"
                 loading={index === 0 ? "eager" : "lazy"}


### PR DESCRIPTION
## Summary

Today is Saturday 2026-04-25 — random category selected: **Accessibility & SEO**.

Six issues found and fixed across the site:

- **Skip-to-main-content link** (`BaseLayout.astro`, `layout.css`): Added a keyboard-accessible skip link that becomes visible on focus, allowing keyboard and screen reader users to bypass repeated navigation. This is a WCAG 2.1 Level A requirement.

- **OG type incorrect on all pages** (`BaseLayout.astro`, `[slug].astro`): `og:type` was hardcoded to `"Article"` on every page including the homepage, archive, search, etc. Added an `ogType` prop defaulting to `"website"`, and `[slug].astro` now passes `"article"` for post pages only.

- **OG image not set on homepage** (`index.astro`): The prop was passed as `openGraphImage` (capital G) but `BaseLayout` destructures it as `opengraphImage`. This silently fell back to the logo for every homepage share instead of using the latest post's image.

- **Web manifest empty name fields** (`site.webmanifest`): `name` and `short_name` were empty strings, breaking PWA install prompts and browser tab labelling.

- **Misleading alt text on category/feature/stats images** (`index.astro`): The "Find Your Favourite Roast", "Roast By Location", "Features", and "Roastatistics" homepage sections all used `"Photo of the roast dinner at {title}"` as alt text — but these are category pages and article thumbnails, not restaurant photos. Changed to `"Preview image for {title}"`.

- **Missing image dimensions in BestRoastLayout** (`BestRoastLayout.astro`): The post thumbnail `<img>` was missing `width`, `height`, and `loading` attributes, causing layout shift and unnecessary eager loading.

## Test plan

- [ ] Tab through the page and confirm the skip link appears on first Tab press and navigates to `#main-content`
- [ ] Check OG tags on homepage with a social media debugger — `og:type` should be `website`, `og:image` should be the latest post's image (not the logo)
- [ ] Check OG tags on a post page — `og:type` should be `article`
- [ ] Add site to Android home screen and confirm name shows as "Roast Dinners In London"
- [ ] Inspect alt text on the Features and Roastatistics section images in devtools

https://claude.ai/code/session_01NAXzu2qj2QKVxvSiKsQt7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAXzu2qj2QKVxvSiKsQt7D)_