### PR TITLE
feat(league-table): add shareable URL links for filter/sort state

### DIFF
--- a/src/components/sort-posts/sort-posts.test.tsx
+++ b/src/components/sort-posts/sort-posts.test.tsx
@@ -112,10 +112,12 @@ const getRoastTitles = (host: HTMLDivElement) =>
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
 });
 
 afterEach(() => {
   document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
 });
 
 describe("sort-posts component", () => {

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -36,6 +36,8 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
     setShowBorough,
     setShowOwner,
     setShowClosedDown,
+    copyShareableLink,
+    copied,
   } = useSortFilter(posts);
 
   const uniqueAreas = useMemo(
@@ -269,6 +271,9 @@ const SortPosts = ({ posts }: { posts: Post[] }) => {
 
           <button type="button" className="clear-button" onClick={clearFilters}>
             Clear All Filters
+          </button>
+          <button type="button" className="share-button" onClick={copyShareableLink}>
+            {copied ? "Copied!" : "Copy shareable link"}
           </button>
         </div>
       )}

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -45,12 +45,9 @@ const SortPosts = ({
     setShowBorough,
     setShowOwner,
     setShowClosedDown,
-<<<<<<< feat/shareable-league-table-links
     copyShareableLink,
     copied,
-=======
     setShowInflationPrice,
->>>>>>> main
   } = useSortFilter(posts);
 
   const uniqueAreas = useMemo(

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -4,7 +4,7 @@ import type { Post } from "../../types";
 import { translateClosedDown, useSortFilter } from "./useSortFilter.tsx";
 
 const getUniqueValues = (posts: Post[], accessor: (post: Post) => string | undefined): string[] =>
-  Array.from(new Set(posts.map(accessor))).filter((v): v is string => v !== undefined && v !== "");
+  Array.from(new Set(posts.map(accessor))).filter((v): v is string => v !== undefined && v !== "").sort();
 
 const SortPosts = ({
   posts,

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type SetStateAction, useMemo, useReducer, useState } from "react";
+import { type ChangeEvent, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import type { Post } from "../../types";
 
 type FilterState = {
@@ -163,10 +163,27 @@ export const translateClosedDown = (
 
 type BooleanStateSetter = (value: SetStateAction<boolean>) => void;
 
+const getInitialStateFromUrl = () => {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  return params;
+};
+
 export const useSortFilter = (posts: Post[]) => {
-  const [sortOrder, setSortOrder] = useState("desc");
-  const [sortColumn, setSortColumn] = useState("rating");
-  const [filters, dispatch] = useReducer(filterReducer, initialFilterState);
+  const urlParams = getInitialStateFromUrl();
+
+  const [sortOrder, setSortOrder] = useState(urlParams?.get("order") ?? "desc");
+  const [sortColumn, setSortColumn] = useState(urlParams?.get("sort") ?? "rating");
+  const [filters, dispatch] = useReducer(filterReducer, {
+    meat: urlParams?.get("meat") ?? "",
+    score: urlParams?.get("score") ?? "",
+    price: urlParams?.get("price") ?? "",
+    area: urlParams?.get("area") ?? "",
+    borough: urlParams?.get("borough") ?? "",
+    owner: urlParams?.get("owner") ?? "",
+    closedDown: urlParams?.get("closedDown") ?? "",
+    year: urlParams?.get("year") ?? "",
+  });
   const [showOptions, setShowOptions] = useState(false);
   const [showYearVisited, setShowYearVisited] = useState(false);
   const [showMeat, setShowMeat] = useState(false);
@@ -176,6 +193,25 @@ export const useSortFilter = (posts: Post[]) => {
   const [showBorough, setShowBorough] = useState(false);
   const [showOwner, setShowOwner] = useState(false);
   const [showClosedDown, setShowClosedDown] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (sortColumn !== "rating") params.set("sort", sortColumn);
+    if (sortOrder !== "desc") params.set("order", sortOrder);
+    for (const [key, value] of Object.entries(filters)) {
+      if (value) params.set(key, value);
+    }
+    const query = params.toString();
+    window.history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
+  }, [sortColumn, sortOrder, filters]);
+
+  const copyShareableLink = useCallback(() => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
 
   const handleCheckboxChange = (setter: BooleanStateSetter) => () => {
     setter((prev) => !prev);
@@ -237,5 +273,7 @@ export const useSortFilter = (posts: Post[]) => {
     setShowBorough,
     setShowOwner,
     setShowClosedDown,
+    copyShareableLink,
+    copied,
   };
 };

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -274,12 +274,9 @@ export const useSortFilter = (posts: Post[]) => {
     setShowBorough,
     setShowOwner,
     setShowClosedDown,
-<<<<<<< feat/shareable-league-table-links
     copyShareableLink,
     copied,
-=======
     showInflationPrice,
     setShowInflationPrice,
->>>>>>> main
   };
 };

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -241,7 +241,7 @@ export const useSortFilter = (posts: Post[]) => {
     [posts, filters, sortColumn, sortOrder]
   );
   const uniqueMeats = useMemo(
-    () => [...new Set(posts.map((post) => post.meats?.nodes[0]?.name).filter(Boolean))],
+    () => [...new Set(posts.map((post) => post.meats?.nodes[0]?.name).filter(Boolean))].sort(),
     [posts]
   );
 

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -497,6 +497,10 @@ p {
   }
 }
 
+.share-button {
+  margin-left: 1rem;
+}
+
 .other-list {
   ul {
     display: flex;

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -391,6 +391,10 @@ p {
     margin: 0;
   }
 
+  .share-button {
+    margin-left: 1rem;
+  }
+
   .show-hide-button {
     margin: 1rem 0;
   }
@@ -495,10 +499,6 @@ p {
     justify-content: flex-start;
     margin-bottom: 1rem;
   }
-}
-
-.share-button {
-  margin-left: 1rem;
 }
 
 .other-list {


### PR DESCRIPTION
Encode filter and sort state into URL query parameters on change, and read them back on load so views can be bookmarked and shared. Adds a "Copy shareable link" button with a brief "Copied!" confirmation.

Closes #371