### PR TITLE
chore(typescript): remove `any` usages and add missing return types

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,3 +1,17 @@
 declare const Alpine: {
   data: (name: string, callback: () => Record<string, unknown>) => void;
 };
+
+interface ClerkUser {
+  id: string;
+}
+
+interface ClerkInstance {
+  loaded: boolean;
+  user: ClerkUser | null | undefined;
+  addListener: (callback: () => void) => void;
+}
+
+interface Window {
+  Clerk?: ClerkInstance;
+}

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import { type ChangeEvent, type ReactElement, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import type { Post } from "../../types";
 
 type FilterState = {
@@ -131,7 +131,7 @@ const filterPosts = (posts: Post[], filters: FilterState): Post[] => {
 export const translateClosedDown = (
   closedDown: string | undefined,
   newSlug: string | undefined
-) => {
+): string | ReactElement | undefined => {
   switch (closedDown) {
     case "closeddown":
       return "Closed Down";
@@ -163,7 +163,7 @@ export const translateClosedDown = (
 
 type BooleanStateSetter = (value: SetStateAction<boolean>) => void;
 
-const getInitialStateFromUrl = () => {
+const getInitialStateFromUrl = (): URLSearchParams | null => {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
   return params;

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -1,5 +1,13 @@
-export default (Alpine: any) => {
-  Alpine.data("wishlistButton", (props: any) => {
+import type { Alpine } from 'alpinejs';
+
+interface WishlistButtonProps {
+  postSlug: string;
+  postTitle: string;
+  postRating: string;
+}
+
+export default (alpine: Alpine) => {
+  alpine.data("wishlistButton", (props: WishlistButtonProps) => {
     const { postSlug, postTitle, postRating } = props;
     return {
       saved: false,
@@ -7,7 +15,7 @@ export default (Alpine: any) => {
       loading: false,
 
       async init() {
-        const clerk = (window as any).Clerk;
+        const clerk = window.Clerk;
         if (!clerk) {
           this.signedOut = true;
           return;
@@ -56,7 +64,7 @@ export default (Alpine: any) => {
 
   queueMicrotask(() => {
     if (document.readyState !== "loading") {
-      Alpine.start();
+      alpine.start();
     }
   });
 };

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -1,5 +1,5 @@
 import type { Clerk as ClerkInstance } from "@clerk/shared/types";
-import type { Alpine as AlpineInstance } from "alpinejs";;
+import type { Alpine as AlpineInstance } from "alpinejs";
 
 type WishlistButtonProps = {
   postSlug: string;
@@ -7,8 +7,8 @@ type WishlistButtonProps = {
   postRating: string | null;
 };
 
-export default (alpine: Alpine) => {
-  Alpine.data("wishlistButton", (props: WishlistButtonProps) => {
+export default (alpine: AlpineInstance) => {
+  Alpine.data("wishlistButton", (props: WishlistButtonProps = {} as WishlistButtonProps) => {
     const { postSlug, postTitle, postRating } = props;
     return {
       saved: false,

--- a/src/lib/getAllRoastDinnerPosts.ts
+++ b/src/lib/getAllRoastDinnerPosts.ts
@@ -20,8 +20,8 @@ async function fetchAllRoastDinnerPosts(): Promise<Post[]> {
   const allPosts: Post[] = [];
 
   while (hasNextPage) {
-    const variables = endCursor ? { after: endCursor } : {};
-    const data = (await fetchGraphQL(GET_ALL_POSTS, variables)) as PostsResponse;
+    const variables: { after?: string } = endCursor ? { after: endCursor } : {};
+    const data = await fetchGraphQL<PostsResponse>(GET_ALL_POSTS, variables);
     const posts = data?.posts;
     const nodes = posts?.nodes ?? [];
     allPosts.push(...nodes);


### PR DESCRIPTION
## Summary

Today's automated quality pass (Saturday → TypeScript & typing category).

- **`src/entrypoints/alpine.ts`**: Replaced all three `any` usages. Added `import type { Alpine } from 'alpinejs'` (the package's own type) and a `WishlistButtonProps` interface for the data component props. The `(window as any).Clerk` cast is now gone — the type comes from the Window augmentation below.
- **`global.d.ts`**: Added `ClerkUser`, `ClerkInstance`, and a `Window` interface augmentation so `window.Clerk` is properly typed everywhere without unsafe casts.
- **`src/components/sort-posts/useSortFilter.tsx`**: Added explicit return type annotations to `translateClosedDown` (`string | ReactElement | undefined`) and `getInitialStateFromUrl` (`URLSearchParams | null`). Added `ReactElement` to the React imports.

## Test plan

- [ ] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] The wishlist button still functions correctly (add/remove, Clerk auth flow)
- [ ] Sort/filter page renders correctly and `translateClosedDown` displays all variants as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9E2fAhyQo88D1tYTgxLbE)_