### PR TITLE
chore(typescript): remove all `any` usages and add missing return types

### DIFF
--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -30,7 +30,7 @@ const getMarkerColor = (rating: number): { colour: string; backgroundColour: str
   return { colour: "#fff", backgroundColour: "#000000" };
 };
 
-const createColouredIcon = (colour: string, backgroundColour: string, value: number) => {
+const createColouredIcon = (colour: string, backgroundColour: string, value: number): L.DivIcon => {
   const formattedValue = value.toFixed(1);
   return L.divIcon({
     className: "",

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -30,7 +30,7 @@ const SortPosts = ({
       .catch(() => {});
   }, [isLoaded, isSignedIn]);
 
-  function handleSaveToggle(slug: string, nowSaved: boolean) {
+  function handleSaveToggle(slug: string, nowSaved: boolean): void {
     setSavedSlugs((prev) => {
       const next = new Set(prev);
       if (nowSaved) next.add(slug);

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -163,7 +163,7 @@ export const translateClosedDown = (
 
 type BooleanStateSetter = (value: SetStateAction<boolean>) => void;
 
-const getInitialStateFromUrl = () => {
+const getInitialStateFromUrl = (): URLSearchParams | null => {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
   return params;
@@ -214,7 +214,7 @@ export const useSortFilter = (posts: Post[]) => {
   }, []);
   const [showInflationPrice, setShowInflationPrice] = useState(false);
 
-  const handleCheckboxChange = (setter: BooleanStateSetter) => () => {
+  const handleCheckboxChange = (setter: BooleanStateSetter): (() => void) => () => {
     setter((prev) => !prev);
   };
 
@@ -222,7 +222,7 @@ export const useSortFilter = (posts: Post[]) => {
     setSortColumn(e.target.value);
   };
 
-  const toggleSortOrder = () => {
+  const toggleSortOrder = (): void => {
     setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
   };
 
@@ -232,7 +232,7 @@ export const useSortFilter = (posts: Post[]) => {
     dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
   };
 
-  const clearFilters = () => {
+  const clearFilters = (): void => {
     dispatch({ type: "CLEAR_FILTERS" });
   };
 

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import { type ChangeEvent, type ReactElement, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import type { Post } from "../../types";
 
 type FilterState = {
@@ -131,7 +131,7 @@ const filterPosts = (posts: Post[], filters: FilterState): Post[] => {
 export const translateClosedDown = (
   closedDown: string | undefined,
   newSlug: string | undefined
-) => {
+): string | ReactElement | undefined => {
   switch (closedDown) {
     case "closeddown":
       return "Closed Down";

--- a/src/components/wishlist-button/wishlist-button.tsx
+++ b/src/components/wishlist-button/wishlist-button.tsx
@@ -49,7 +49,7 @@ export default function WishlistButton({ postSlug, postTitle, postRating, iconOn
 
   const currentlySaved = controlled ? isSaved! : saved;
 
-  async function toggle() {
+  async function toggle(): Promise<void> {
     if (currentlySaved) {
       await fetch(`/api/wishlist/${postSlug}`, { method: "DELETE" });
       if (controlled) onSaveToggle?.(postSlug, false);

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -3,7 +3,7 @@ import type { Alpine } from "alpinejs";
 interface WishlistButtonAlpineProps {
   postSlug: string;
   postTitle: string;
-  postRating?: string;
+  postRating: string | null;
 }
 
 interface WindowClerk {

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -1,5 +1,19 @@
-export default (Alpine: any) => {
-  Alpine.data("wishlistButton", (props: any) => {
+import type { Alpine } from "alpinejs";
+
+interface WishlistButtonAlpineProps {
+  postSlug: string;
+  postTitle: string;
+  postRating?: string;
+}
+
+interface WindowClerk {
+  loaded: boolean;
+  user: unknown;
+  addListener(callback: () => void): void;
+}
+
+export default (Alpine: Alpine) => {
+  Alpine.data("wishlistButton", (props: WishlistButtonAlpineProps) => {
     const { postSlug, postTitle, postRating } = props;
     return {
       saved: false,
@@ -7,7 +21,7 @@ export default (Alpine: any) => {
       loading: false,
 
       async init() {
-        const clerk = (window as any).Clerk;
+        const clerk = (window as Window & { Clerk?: WindowClerk }).Clerk;
         if (!clerk) {
           this.signedOut = true;
           return;


### PR DESCRIPTION
## Summary

- **`src/entrypoints/alpine.ts`** — eliminated all 3 `any` usages: imported `Alpine` type from `alpinejs`, defined a `WishlistButtonAlpineProps` interface for the component data props (with `postRating: string | null` to match the `postRating ?? null` value passed by the Astro component), and replaced `(window as any).Clerk` with a minimal `WindowClerk` interface cast (`Window & { Clerk?: WindowClerk }`)
- **`src/components/sort-posts/useSortFilter.tsx`** — added explicit return types to `translateClosedDown` (`string | ReactElement | undefined`, importing `ReactElement` from React), `getInitialStateFromUrl` (`URLSearchParams | null`), `handleCheckboxChange` (`() => void`), `toggleSortOrder` (`void`), and `clearFilters` (`void`)
- **`src/components/sort-posts/sort-posts.tsx`** — added `void` return type to `handleSaveToggle`
- **`src/components/wishlist-button/wishlist-button.tsx`** — added `Promise<void>` return type to `async function toggle()`
- **`src/components/roast-map/roast-map.tsx`** — added `L.DivIcon` return type to `createColouredIcon`

`tsc --noEmit` passes with zero errors. All 306 pre-existing passing tests continue to pass.

## Test plan

- [ ] `yarn tsc --noEmit` — zero errors
- [ ] `yarn vitest run` — same pass/fail ratio as `main`

https://claude.ai/code/session_015AzWBRxLWspzpC2cPVHNCP