### PR TITLE
fix(types): replace `any` in alpine.ts with precise types

### DIFF
--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -1,5 +1,14 @@
-export default (Alpine: any) => {
-  Alpine.data("wishlistButton", (props: any) => {
+import type { Alpine as AlpineInstance } from "alpinejs";
+import type { Clerk as ClerkInstance } from "@clerk/shared/types";
+
+interface WishlistButtonProps {
+  postSlug: string;
+  postTitle: string;
+  postRating?: string;
+}
+
+export default (Alpine: AlpineInstance) => {
+  Alpine.data("wishlistButton", (props: WishlistButtonProps) => {
     const { postSlug, postTitle, postRating } = props;
     return {
       saved: false,
@@ -7,7 +16,7 @@ export default (Alpine: any) => {
       loading: false,
 
       async init() {
-        const clerk = (window as any).Clerk;
+        const clerk = (window as unknown as { Clerk?: ClerkInstance }).Clerk;
         if (!clerk) {
           this.signedOut = true;
           return;

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -1,5 +1,5 @@
-import type { Alpine as AlpineInstance } from "alpinejs";
 import type { Clerk as ClerkInstance } from "@clerk/shared/types";
+import type { Alpine as AlpineInstance } from "alpinejs";
 
 interface WishlistButtonProps {
   postSlug: string;


### PR DESCRIPTION
## Summary

- Replaces all three `any` usages in `src/entrypoints/alpine.ts` with proper TypeScript types
- Adds a `WishlistButtonProps` interface to make the wishlist button data contract explicit
- Types `window.Clerk` with a narrowly-scoped cast rather than the unsafe `as any`

## Changes

**`src/entrypoints/alpine.ts`**

| Before | After |
|--------|-------|
| `(Alpine: any)` | `(Alpine: AlpineInstance)` — imported as `Alpine` from `alpinejs` |
| `(props: any)` | `(props: WishlistButtonProps)` — new interface with `postSlug`, `postTitle`, `postRating?` |
| `(window as any).Clerk` | `(window as unknown as { Clerk?: ClerkInstance }).Clerk` — typed via `@clerk/shared/types` |

The narrowly-scoped window cast means `.loaded`, `.user`, and `.addListener` are all fully typed through the Clerk SDK's own `Clerk` interface, with no escape hatch needed.

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors (verified locally)
- [ ] No runtime behaviour changes — types-only fix

https://claude.ai/code/session_013zGPUqPR6UUbPSKWdsaRt6

---
_Generated by [Claude Code](https://claude.ai/code/session_013zGPUqPR6UUbPSKWdsaRt6)_