### PR TITLE
perf: defer header auth hydration and preserve map state across filter changes

### DIFF
--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -18,7 +18,7 @@ import { HeaderAuthDesktop, HeaderAuthMobile } from "./HeaderAuth";
       </div>
 
       <div class="header-top-right">
-        <HeaderAuthDesktop client:load />
+        <HeaderAuthDesktop client:idle />
         <SocialLinks className="socials header-socials" />
       </div>
 
@@ -37,7 +37,7 @@ import { HeaderAuthDesktop, HeaderAuthMobile } from "./HeaderAuth";
       <a href="/to-do-list">To-Do List</a>
       <a href="/search">Search</a>
       <a href="/archive">Archive</a>
-      <HeaderAuthMobile client:load />
+      <HeaderAuthMobile client:idle />
       <div class="dropdown">
         <a
           href="/about"

--- a/src/components/roast-map/roast-map.test.tsx
+++ b/src/components/roast-map/roast-map.test.tsx
@@ -37,6 +37,15 @@ const leafletMocks = vi.hoisted(() => {
 
   const divIconMock = vi.fn();
 
+  const layerGroupClearLayersMock = vi.fn();
+  const layerGroupMock = vi.fn(() => {
+    const layer: { addTo: ReturnType<typeof vi.fn>; clearLayers: ReturnType<typeof vi.fn> } = {
+      addTo: vi.fn(() => layer),
+      clearLayers: layerGroupClearLayersMock
+    };
+    return layer;
+  });
+
   return {
     mapSetViewMock,
     mapRemoveMock,
@@ -47,7 +56,9 @@ const leafletMocks = vi.hoisted(() => {
     markerBindTooltipMock,
     markerBindPopupMock,
     markerMock,
-    divIconMock
+    divIconMock,
+    layerGroupClearLayersMock,
+    layerGroupMock
   };
 });
 
@@ -56,7 +67,8 @@ vi.mock("leaflet", () => ({
     map: leafletMocks.mapMock,
     tileLayer: leafletMocks.tileLayerMock,
     marker: leafletMocks.markerMock,
-    divIcon: leafletMocks.divIconMock
+    divIcon: leafletMocks.divIconMock,
+    layerGroup: leafletMocks.layerGroupMock
   }
 }));
 
@@ -108,6 +120,8 @@ beforeEach(() => {
   leafletMocks.markerMock.mockClear();
   leafletMocks.divIconMock.mockReset();
   leafletMocks.divIconMock.mockImplementation((options: unknown) => ({ options }));
+  leafletMocks.layerGroupMock.mockClear();
+  leafletMocks.layerGroupClearLayersMock.mockReset();
 });
 
 afterEach(() => {
@@ -184,11 +198,13 @@ describe("roast-map component", () => {
       title: "Closed One (8.6/10)",
       alt: "Closed One (8.6/10)"
     });
-    expect(leafletMocks.mapRemoveMock).toHaveBeenCalledTimes(1);
+    // Map is reused across filter changes; remove is only called on unmount.
+    expect(leafletMocks.mapRemoveMock).not.toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();
     });
+    expect(leafletMocks.mapRemoveMock).toHaveBeenCalledTimes(1);
   });
 
   test("filters visible markers by minimum rating", async () => {

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -54,6 +54,8 @@ const createColouredIcon = (colour: string, backgroundColour: string, value: num
 
 export default function RoastMap({ markers }: Props) {
   const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markerLayerRef = useRef<L.LayerGroup | null>(null);
   const [showClosed, setShowClosed] = useState(false);
   const [minRating, setMinRating] = useState(0);
   const filteredMarkers = useMemo(
@@ -73,6 +75,7 @@ export default function RoastMap({ markers }: Props) {
   );
   const totalMarkers = markers.length;
 
+  // Initialise the map and tile layer once; preserve zoom/pan across filter changes.
   useEffect(() => {
     if (!mapRef.current) return;
 
@@ -82,9 +85,25 @@ export default function RoastMap({ markers }: Props) {
       attribution: "&copy; OpenStreetMap contributors",
     }).addTo(map);
 
+    const layer = L.layerGroup().addTo(map);
+    mapInstanceRef.current = map;
+    markerLayerRef.current = layer;
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markerLayerRef.current = null;
+    };
+  }, []);
+
+  // Swap out only the markers when filters change, leaving the map position intact.
+  useEffect(() => {
+    const layer = markerLayerRef.current;
+    if (!layer) return;
+
+    layer.clearLayers();
 
     filteredMarkers.forEach(({ lat, lng, label, rating, slug }) => {
-
       const { colour, backgroundColour } = getMarkerColor(rating);
       const icon = createColouredIcon(colour, backgroundColour, rating);
       const markerLabel = label ? `${label} (${rating.toFixed(1)}/10)` : `Roast location (${rating.toFixed(1)}/10)`;
@@ -93,14 +112,10 @@ export default function RoastMap({ markers }: Props) {
         title: markerLabel,
         alt: markerLabel,
       })
-        .addTo(map)
+        .addTo(layer)
         .bindTooltip(markerLabel, { direction: "top", opacity: 0.9 })
         .bindPopup(`<a href="/${slug}">${label}</a> - ${rating}/10`);
     });
-
-    return () => {
-      map.remove();
-    };
   }, [filteredMarkers]);
 
   return (


### PR DESCRIPTION
## Summary

Wednesday performance & Astro island optimisation pass.

### Changes

**`client:load` → `client:idle` on header auth components (`header.astro`)**

`HeaderAuthDesktop` and `HeaderAuthMobile` were hydrated immediately on every page load, pulling in the full Clerk bundle during the critical path. The auth buttons are non-critical for first interaction — the `useAuthFlag` hook already defers their visibility via a `useEffect` cookie check anyway — so deferring to `client:idle` avoids blocking initial paint with ~50 KB of auth JS.

**RoastMap: preserve map state across filter changes (`roast-map.tsx`)**

The single `useEffect` previously destroyed and recreated the entire Leaflet map every time the user adjusted the minimum-rating slider or toggled "Show closed places". This reset the user's zoom and pan position on every interaction and was unnecessarily expensive.

The fix splits the effect into two:
1. **Mount effect** (empty deps): initialises the map, tile layer, and a `LayerGroup` once. Tears down only on unmount.
2. **Marker effect** (deps: `filteredMarkers`): clears and redraws only the marker layer when filters change, leaving the map position intact.

**Updated tests (`roast-map.test.tsx`)**

- Added `layerGroup` to the Leaflet mock (markers are now added to a `LayerGroup` rather than directly to the map).
- Corrected the assertion that `map.remove()` was called during a filter change; it is now only called on unmount, which is the correct behaviour.

## Test plan

- [ ] All 326 unit tests pass (`npm test`)
- [ ] Visit the maps page, adjust the rating slider and toggle "Show closed" — the map no longer jumps back to the default zoom/position on each change
- [ ] Auth buttons in the header still appear correctly after page load (just slightly deferred until browser idle)

---
_Generated by [Claude Code](https://claude.ai/code/session_016LENrnbSU4QY8g2dhxmTgF)_