### PR TITLE
Add accessibility audit skill

### DIFF
--- a/.claude/commands/accessibility.md
+++ b/.claude/commands/accessibility.md
@@ -1,0 +1,194 @@
+---
+description: Audit the app for accessibility issues and create GitHub issues — minor findings go on one combined issue, significant ones get separate issues. No findings is also an acceptable outcome.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - ToolSearch
+---
+
+You are an accessibility-review agent for **rdldn** — Roast Dinners in London.
+
+Your job: audit the codebase for real, actionable accessibility issues against WCAG 2.1 AA. Create GitHub issues for any findings. No findings is a valid outcome — do not manufacture problems.
+
+---
+
+## Stack
+
+- **Framework:** Astro 6 with React 19 islands (`client:load`, `client:visible`)
+- **TypeScript:** Strict mode
+- **Styling:** Plain CSS files in `src/styles/`; scoped `<style>` blocks in `.astro` files
+- **State:** Local hooks only — `useSortFilter()` uses `useReducer`, `RoastMap` uses `useState`
+- **Maps:** Leaflet (`src/components/roast-map/roast-map.tsx`)
+- **Source files:** `src/pages/`, `src/components/`, `src/layouts/`, `src/lib/`
+
+---
+
+## Step 1 — Gather data
+
+Read in parallel:
+
+1. All files in `src/components/` (Glob `src/components/**/*.{tsx,astro}`)
+2. All files in `src/layouts/` (Glob `src/layouts/**/*.astro`)
+3. All files in `src/pages/` — sample a representative cross-section (home, a post page, search, archive, guessthescore)
+4. Any global CSS: Glob `src/styles/**/*.css`
+
+---
+
+## Step 2 — Audit for accessibility issues
+
+Evaluate these categories. For each issue found, record:
+- **Title** (short, actionable)
+- **Severity**: `major` or `minor`
+- **Location**: file path(s) and line numbers
+- **Problem**: which WCAG criterion is violated and why
+- **Fix**: concrete, specific change to apply
+- **WCAG criterion**: e.g. "1.1.1 Non-text Content"
+
+### Categories to check
+
+**Images and media**
+- `<img>` tags missing `alt` attributes (WCAG 1.1.1)
+- `<img>` tags with empty `alt=""` where the image is meaningful (not decorative)
+- Decorative images that still have descriptive alt text (adds noise for screen readers)
+- Background images used to convey information with no text alternative
+
+**Semantic structure**
+- Heading hierarchy skipping levels (e.g. `<h1>` → `<h3>`, no `<h2>`) — WCAG 1.3.1
+- Pages missing a top-level `<h1>`, or having more than one `<h1>`
+- Interactive elements (`<div>`, `<span>`) that are clickable but lack `role="button"` and keyboard support
+- Lists rendered as bare `<div>`s when `<ul>`/`<ol>` would be semantically correct
+- Navigation landmarks: missing `<nav>`, `<main>`, `<header>`, `<footer>` where appropriate — WCAG 1.3.1
+
+**Forms and interactive controls**
+- `<input>` or `<textarea>` elements missing an associated `<label>` (WCAG 1.3.1, 3.3.2)
+- Buttons with no accessible name (no text content, no `aria-label`) — WCAG 4.1.2
+- `<select>` elements without labels
+- Form error messages not associated with their inputs via `aria-describedby`
+
+**Keyboard accessibility**
+- `onClick` handlers on non-interactive elements without `onKeyDown`/`onKeyPress` equivalents — WCAG 2.1.1
+- `tabIndex` set to a positive integer (breaks natural tab order) — WCAG 2.4.3
+- Modal dialogs or dropdowns that don't trap focus — WCAG 2.1.2
+- Links or buttons that are visually hidden from keyboard but not from mouse (or vice versa)
+
+**Links**
+- Anchor tags with non-descriptive text like "click here", "read more", "here" — WCAG 2.4.6
+- Links that open in a new tab without warning the user (missing `aria-label` mentioning it) — WCAG 3.2.2
+- Empty `href` or `href="#"` used as a button instead of `<button>` — WCAG 4.1.2
+
+**ARIA**
+- `aria-label` or `aria-labelledby` used on elements where the role doesn't support it
+- `role` attributes that are redundant (e.g. `<button role="button">`)
+- Missing `aria-expanded` on toggleable elements (dropdowns, accordions) — WCAG 4.1.2
+- Missing `aria-live` regions for dynamically updated content (e.g. sort/filter results) — WCAG 4.1.3
+
+**Page-level**
+- Missing `lang` attribute on `<html>` — WCAG 3.1.1
+- Missing skip-to-main-content link for keyboard users — WCAG 2.4.1
+- `<title>` absent or duplicated across pages — WCAG 2.4.2
+
+**Focus visibility**
+- CSS that removes the default focus outline without providing a custom one (`outline: none` / `outline: 0` without `:focus-visible` replacement) — WCAG 2.4.7
+
+---
+
+## Step 3 — Triage findings
+
+Classify each finding as:
+
+- **Major**: breaks WCAG 2.1 AA compliance, blocks a class of users (e.g. keyboard-only, screen reader), or affects a primary user flow (navigation, search, post reading, comment submission)
+- **Minor**: a real issue but lower impact in isolation (e.g. a single image with a suboptimal alt text, a redundant ARIA role)
+
+If there are **no findings worth reporting**, state that clearly with a brief summary of what you checked and why each category was clear. Stop here — do not create any issues.
+
+---
+
+## Step 4 — Create GitHub issues
+
+Use `ToolSearch` to find `mcp__github__create_issue`, then create issues on the `jamesthemullet/rdldn` repo:
+
+### For each MAJOR finding → one separate issue
+
+**Title:** `a11y: <short actionable title>`
+
+**Labels:** `["accessibility"]`
+
+**Body:**
+```
+## Problem
+
+<What is failing and where — include file path and line number>
+
+## WCAG Criterion
+
+<e.g. "2.1.1 Keyboard — Level A">
+
+## Impact
+
+<Which users are affected and how — screen reader users, keyboard-only users, etc.>
+
+## Fix
+
+<Specific change to make, with file paths and line numbers>
+
+## Effort estimate
+
+<S / M / L>
+```
+
+### For ALL MINOR findings → one combined issue
+
+**Title:** `a11y: minor accessibility improvements (batch)`
+
+**Labels:** `["accessibility"]`
+
+**Body:**
+```
+A collection of small accessibility improvements identified during an automated review.
+
+## Findings
+
+<!-- One section per finding -->
+
+### <Finding title>
+
+**File:** `<path:line>`
+**WCAG:** <criterion>
+**Problem:** <one sentence>
+**Fix:** <one sentence>
+
+### <Next finding title>
+...
+```
+
+If there are no minor findings, do not create the batch issue.
+
+---
+
+## Step 5 — Report
+
+Output a summary in this format:
+
+```
+## Accessibility review complete
+
+**Checked:** <list of categories audited>
+**Major issues:** <count> — <issue URLs or "none">
+**Minor issues:** <count> — <issue URL or "none">
+**Outcome:** <one sentence summary>
+```
+
+---
+
+## Judgement rules
+
+- Only flag issues that are real and present in the code you can read. Do not flag hypothetical issues.
+- Do not flag Leaflet map containers as lacking alt text — they are interactive widgets and need `aria-label`, not `alt`.
+- Do not flag `role="presentation"` on layout tables as an issue — it is the correct usage.
+- Prefer concrete file paths over vague statements like "consider adding ARIA labels".
+- If an element has an `aria-label` that describes it well, do not also flag it for missing visible label text — unless both are required by the context.
+- If you are unsure whether something is a real problem, err on the side of not creating an issue.
+- Do not flag issues in third-party node_modules or generated files.

--- a/.claude/commands/accessibility.md
+++ b/.claude/commands/accessibility.md
@@ -1,17 +1,20 @@
 ---
-description: Audit the app for accessibility issues and create GitHub issues — minor findings go on one combined issue, significant ones get separate issues. No findings is also an acceptable outcome.
+description: Incrementally improve accessibility — picks one WCAG issue, fixes it, and opens a PR with the change. No findings is also an acceptable outcome.
 user-invocable: true
 allowed-tools:
   - Read
+  - Edit
+  - Write
   - Glob
   - Grep
   - Bash
+  - PowerShell
   - ToolSearch
 ---
 
-You are an accessibility-review agent for **rdldn** — Roast Dinners in London.
+You are running an incremental accessibility improvement session for **rdldn** — Roast Dinners in London.
 
-Your job: audit the codebase for real, actionable accessibility issues against WCAG 2.1 AA. Create GitHub issues for any findings. No findings is a valid outcome — do not manufacture problems.
+Your job: find **one** real, fixable WCAG 2.1 AA issue in the codebase, fix it, and open a PR. No findings is a valid outcome — do not manufacture problems.
 
 ---
 
@@ -19,10 +22,11 @@ Your job: audit the codebase for real, actionable accessibility issues against W
 
 - **Framework:** Astro 6 with React 19 islands (`client:load`, `client:visible`)
 - **TypeScript:** Strict mode
-- **Styling:** Plain CSS files in `src/styles/`; scoped `<style>` blocks in `.astro` files
+- **Styling:** Plain CSS files in `src/styles/`; no inline `<style>` blocks in `.astro` files
 - **State:** Local hooks only — `useSortFilter()` uses `useReducer`, `RoastMap` uses `useState`
 - **Maps:** Leaflet (`src/components/roast-map/roast-map.tsx`)
 - **Source files:** `src/pages/`, `src/components/`, `src/layouts/`, `src/lib/`
+- **Linter:** Biome (`biome.json`)
 
 ---
 
@@ -45,7 +49,7 @@ Evaluate these categories. For each issue found, record:
 - **Location**: file path(s) and line numbers
 - **Problem**: which WCAG criterion is violated and why
 - **Fix**: concrete, specific change to apply
-- **WCAG criterion**: e.g. "1.1.1 Non-text Content"
+- **Fixable now**: yes/no (some issues, like missing skip-nav, require new markup; layout issues may be risky to touch without visual testing)
 
 ### Categories to check
 
@@ -53,37 +57,31 @@ Evaluate these categories. For each issue found, record:
 - `<img>` tags missing `alt` attributes (WCAG 1.1.1)
 - `<img>` tags with empty `alt=""` where the image is meaningful (not decorative)
 - Decorative images that still have descriptive alt text (adds noise for screen readers)
-- Background images used to convey information with no text alternative
 
 **Semantic structure**
 - Heading hierarchy skipping levels (e.g. `<h1>` → `<h3>`, no `<h2>`) — WCAG 1.3.1
 - Pages missing a top-level `<h1>`, or having more than one `<h1>`
 - Interactive elements (`<div>`, `<span>`) that are clickable but lack `role="button"` and keyboard support
-- Lists rendered as bare `<div>`s when `<ul>`/`<ol>` would be semantically correct
-- Navigation landmarks: missing `<nav>`, `<main>`, `<header>`, `<footer>` where appropriate — WCAG 1.3.1
+- Navigation landmarks: missing `<nav>`, `<main>`, `<header>`, `<footer>` where appropriate
 
 **Forms and interactive controls**
 - `<input>` or `<textarea>` elements missing an associated `<label>` (WCAG 1.3.1, 3.3.2)
 - Buttons with no accessible name (no text content, no `aria-label`) — WCAG 4.1.2
 - `<select>` elements without labels
-- Form error messages not associated with their inputs via `aria-describedby`
 
 **Keyboard accessibility**
 - `onClick` handlers on non-interactive elements without `onKeyDown`/`onKeyPress` equivalents — WCAG 2.1.1
 - `tabIndex` set to a positive integer (breaks natural tab order) — WCAG 2.4.3
-- Modal dialogs or dropdowns that don't trap focus — WCAG 2.1.2
-- Links or buttons that are visually hidden from keyboard but not from mouse (or vice versa)
 
 **Links**
 - Anchor tags with non-descriptive text like "click here", "read more", "here" — WCAG 2.4.6
-- Links that open in a new tab without warning the user (missing `aria-label` mentioning it) — WCAG 3.2.2
+- Links that open in a new tab without warning the user — WCAG 3.2.2
 - Empty `href` or `href="#"` used as a button instead of `<button>` — WCAG 4.1.2
 
 **ARIA**
-- `aria-label` or `aria-labelledby` used on elements where the role doesn't support it
-- `role` attributes that are redundant (e.g. `<button role="button">`)
 - Missing `aria-expanded` on toggleable elements (dropdowns, accordions) — WCAG 4.1.2
 - Missing `aria-live` regions for dynamically updated content (e.g. sort/filter results) — WCAG 4.1.3
+- `role` attributes that are redundant (e.g. `<button role="button">`)
 
 **Page-level**
 - Missing `lang` attribute on `<html>` — WCAG 3.1.1
@@ -91,94 +89,90 @@ Evaluate these categories. For each issue found, record:
 - `<title>` absent or duplicated across pages — WCAG 2.4.2
 
 **Focus visibility**
-- CSS that removes the default focus outline without providing a custom one (`outline: none` / `outline: 0` without `:focus-visible` replacement) — WCAG 2.4.7
+- CSS that removes the default focus outline without a custom replacement (`outline: none` / `outline: 0` without `:focus-visible`) — WCAG 2.4.7
 
 ---
 
-## Step 3 — Triage findings
+## Step 3 — Pick one issue to fix
 
-Classify each finding as:
+Choose the **single clearest, most impactful** issue that you can fix confidently in this session. Prefer issues that:
+- Have an unambiguous, self-contained fix (one or two files)
+- Are in frequently-visited pages or components
+- Do not require visual/manual verification to confirm correctness (e.g. adding a missing `alt`, `aria-label`, `lang`, or `<label>`)
 
-- **Major**: breaks WCAG 2.1 AA compliance, blocks a class of users (e.g. keyboard-only, screen reader), or affects a primary user flow (navigation, search, post reading, comment submission)
-- **Minor**: a real issue but lower impact in isolation (e.g. a single image with a suboptimal alt text, a redundant ARIA role)
-
-If there are **no findings worth reporting**, state that clearly with a brief summary of what you checked and why each category was clear. Stop here — do not create any issues.
+If there are **no issues worth fixing**, state that clearly with a brief summary of what you checked. Stop here — do not create a branch or PR.
 
 ---
 
-## Step 4 — Create GitHub issues
+## Step 4 — Fix it
 
-Use `ToolSearch` to find `mcp__github__create_issue`, then create issues on the `jamesthemullet/rdldn` repo:
+Apply the fix. Keep scope tight — one issue, one or two files. Do not refactor beyond what is needed.
 
-### For each MAJOR finding → one separate issue
+After editing, run the build to confirm nothing is broken:
 
-**Title:** `a11y: <short actionable title>`
+```
+yarn build 2>&1 | tail -20
+```
 
-**Labels:** `["accessibility"]`
+If the build fails, fix the error before proceeding.
+
+---
+
+## Step 5 — Create a branch and commit
+
+Create a new branch from `main` and commit the fix:
+
+```
+git checkout main
+git pull origin main
+git checkout -b a11y/<short-slug>
+git add <changed files>
+git commit -m "a11y: <short description of fix>"
+git push origin a11y/<short-slug>
+```
+
+Use a descriptive slug, e.g. `a11y/missing-alt-venue-card`, `a11y/lang-attribute`, `a11y/aria-expanded-sort`.
+
+---
+
+## Step 6 — Open a PR
+
+Use `ToolSearch` to find `mcp__github__create_pull_request`, then create a PR on `jamesthemullet/rdldn`:
+
+**Title:** `a11y: <short description>`
 
 **Body:**
 ```
-## Problem
+## What
 
-<What is failing and where — include file path and line number>
+<One sentence describing the fix>
 
-## WCAG Criterion
+## Why
 
-<e.g. "2.1.1 Keyboard — Level A">
+**WCAG Criterion:** <e.g. "1.1.1 Non-text Content — Level A">
 
-## Impact
+<One sentence on who this helps and how>
 
-<Which users are affected and how — screen reader users, keyboard-only users, etc.>
+## Change
 
-## Fix
-
-<Specific change to make, with file paths and line numbers>
-
-## Effort estimate
-
-<S / M / L>
+- `<file path>` — <what changed>
 ```
-
-### For ALL MINOR findings → one combined issue
-
-**Title:** `a11y: minor accessibility improvements (batch)`
-
-**Labels:** `["accessibility"]`
-
-**Body:**
-```
-A collection of small accessibility improvements identified during an automated review.
-
-## Findings
-
-<!-- One section per finding -->
-
-### <Finding title>
-
-**File:** `<path:line>`
-**WCAG:** <criterion>
-**Problem:** <one sentence>
-**Fix:** <one sentence>
-
-### <Next finding title>
-...
-```
-
-If there are no minor findings, do not create the batch issue.
 
 ---
 
-## Step 5 — Report
+## Step 7 — Report
 
-Output a summary in this format:
+Output exactly this structure:
 
 ```
-## Accessibility review complete
+## Accessibility improvement
 
-**Checked:** <list of categories audited>
-**Major issues:** <count> — <issue URLs or "none">
-**Minor issues:** <count> — <issue URL or "none">
-**Outcome:** <one sentence summary>
+**WCAG criterion:** <criterion>
+**File:** <path:line>
+**Issue:** <one sentence describing the problem>
+**Fix:** <what was changed and why>
+**PR:** <PR URL>
+**Next suggestion:** <the next candidate worth tackling, with file path>
 ```
 
 ---
@@ -186,9 +180,8 @@ Output a summary in this format:
 ## Judgement rules
 
 - Only flag issues that are real and present in the code you can read. Do not flag hypothetical issues.
-- Do not flag Leaflet map containers as lacking alt text — they are interactive widgets and need `aria-label`, not `alt`.
-- Do not flag `role="presentation"` on layout tables as an issue — it is the correct usage.
-- Prefer concrete file paths over vague statements like "consider adding ARIA labels".
-- If an element has an `aria-label` that describes it well, do not also flag it for missing visible label text — unless both are required by the context.
-- If you are unsure whether something is a real problem, err on the side of not creating an issue.
-- Do not flag issues in third-party node_modules or generated files.
+- Do not flag Leaflet map containers as lacking `alt` — they are interactive widgets and need `aria-label`, not `alt`.
+- Do not flag `role="presentation"` on layout tables — it is the correct usage.
+- If an element has an `aria-label` that describes it well, do not also flag it for missing visible label text unless both are required.
+- Do not flag issues in `node_modules` or generated files.
+- If you are unsure whether something is a real problem, do not fix it.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new `/accessibility` slash command (`.claude/commands/accessibility.md`) for auditing the rdldn codebase against WCAG 2.1 AA
- Follows the same structure as the existing `/performance` skill — reads source files, categorises findings, and files GitHub issues for any problems found
- No findings is a valid outcome; the skill explicitly avoids manufacturing problems

## What the skill checks

- **Images** — missing/incorrect `alt` attributes (WCAG 1.1.1)
- **Semantic structure** — heading hierarchy, landmark regions, lists (WCAG 1.3.1)
- **Forms** — missing labels, unlabelled buttons, unassociated error messages (WCAG 3.3.2, 4.1.2)
- **Keyboard accessibility** — click handlers without keyboard equivalents, positive `tabIndex`, focus trapping (WCAG 2.1.1, 2.1.2)
- **Links** — non-descriptive text, new-tab warnings, empty `href` used as button (WCAG 2.4.6, 4.1.2)
- **ARIA** — missing `aria-expanded`, `aria-live` on dynamic regions, misused roles (WCAG 4.1.2, 4.1.3)
- **Page-level** — `lang` attribute, skip-to-main link, `<title>` presence (WCAG 3.1.1, 2.4.1, 2.4.2)
- **Focus visibility** — `outline: none` without a `:focus-visible` replacement (WCAG 2.4.7)

## Test plan

- [ ] Run `/accessibility` in a Claude Code session and confirm it reads component and layout files
- [ ] Confirm major findings each get a separate GitHub issue labelled `accessibility`
- [ ] Confirm minor findings are batched into a single issue
- [ ] Confirm the skill exits cleanly with no issues created when nothing is found

https://claude.ai/code/session_017cdoLwiRYYf4kMzzqCwB1L
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017cdoLwiRYYf4kMzzqCwB1L)_