### PR TITLE
fix: restore mobile nav toggle script

### DIFF
--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -52,4 +52,26 @@ import { HeaderAuthDesktop, HeaderAuthMobile } from "./HeaderAuth";
       </div>
     </nav>
   </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const navToggle = document.getElementById("nav-toggle");
+      const navContainer = document.querySelector(".nav-container");
+      const dropdownToggle = document.querySelector(".dropdown-toggle");
+      const dropdown = document.querySelector(".dropdown");
+
+      navToggle?.addEventListener("click", () => {
+        const isOpen = navToggle.classList.toggle("open");
+        navToggle.setAttribute("aria-expanded", isOpen.toString());
+        navContainer?.classList.toggle("open");
+      });
+
+      dropdownToggle?.addEventListener("click", (e) => {
+        if (window.innerWidth < 1024) {
+          e.preventDefault();
+          const isOpen = dropdown?.classList.toggle("open");
+          dropdownToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+        }
+      });
+    });
+  </script>
 </header>

--- a/tests/e2e/mobile-nav.spec.ts
+++ b/tests/e2e/mobile-nav.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("mobile nav toggle", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("hamburger button opens and closes the nav menu", async ({ page }) => {
+    await page.goto("/");
+
+    const toggle = page.locator("#nav-toggle");
+    const menu = page.locator("#nav-menu");
+
+    await expect(toggle).toBeVisible();
+    await expect(menu).not.toBeVisible();
+
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await toggle.click();
+    await expect(menu).not.toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("nav links are reachable after opening the menu", async ({ page }) => {
+    await page.goto("/");
+
+    await page.locator("#nav-toggle").click();
+
+    const nav = page.locator("#nav-menu");
+    await expect(nav.getByRole("link", { name: "League Of Roasts" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Search" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Archive" })).toBeVisible();
+  });
+});
+
+test.describe("desktop nav", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("hamburger button is hidden and menu is always visible", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("#nav-toggle")).toBeHidden();
+    await expect(page.locator("#nav-menu")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- The `dbd3971` (wishlist) commit accidentally deleted the `<script>` block from `header.astro` that wires up click handlers for the mobile hamburger menu
- Without it, tapping the menu button on mobile had no effect — the `open` class was never toggled on `#nav-toggle` or `.nav-container`
- This restores the script exactly as it existed before (including the `aria-expanded` updates added by the accessibility fix)

## Test plan

- [ ] On a mobile viewport (< 1024px), tap the hamburger button — the nav menu should open and close
- [ ] The dropdown "About ▼" link should expand/collapse on tap at mobile widths
- [ ] On desktop (≥ 1024px), the menu should remain visible and the button hidden as before

https://claude.ai/code/session_01HqJ8vrZGBqD8AkF125YGnw

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqJ8vrZGBqD8AkF125YGnw)_