### PR TITLE
refactor: replace unsafe cast with type guard in handleFilterChange

### DIFF
--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -27,6 +27,9 @@ const initialFilterState: FilterState = {
   year: "",
 };
 
+const filterStateKeys = new Set<string>(Object.keys(initialFilterState));
+const isFilterKey = (name: string): name is keyof FilterState => filterStateKeys.has(name);
+
 const filterReducer = (state: FilterState, action: FilterAction): FilterState => {
   switch (action.type) {
     case "SET_FILTER":
@@ -229,7 +232,10 @@ export const useSortFilter = (posts: Post[]) => {
   const handleFilterChange = (
     e: ChangeEvent<HTMLSelectElement> | ChangeEvent<HTMLInputElement>
   ) => {
-    dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
+    const { name, value } = e.target;
+    if (isFilterKey(name)) {
+      dispatch({ type: "SET_FILTER", name, value });
+    }
   };
 
   const clearFilters = (): void => {


### PR DESCRIPTION
## Summary
- `handleFilterChange` in `useSortFilter.tsx` was casting `e.target.name` (an unvalidated DOM string) directly to `keyof FilterState` with `as`, bypassing type safety — a mismatch would silently dispatch an invalid action with no compile-time or runtime error
- Added an `isFilterKey` type guard backed by a `Set` of the actual `initialFilterState` keys, then used the guard inside `handleFilterChange` so TypeScript narrows the type properly without a cast

## Category
Strict typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)