### PR TITLE
style: move wishlist icon span styles to CSS class

### DIFF
--- a/src/components/wishlist-button/wishlist-button.css
+++ b/src/components/wishlist-button/wishlist-button.css
@@ -39,3 +39,10 @@
   opacity: 0.6;
   cursor: default;
 }
+
+.wishlist-btn__icon {
+  line-height: 1;
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+}

--- a/src/components/wishlist-button/wishlist-button.tsx
+++ b/src/components/wishlist-button/wishlist-button.tsx
@@ -73,7 +73,7 @@ export default function WishlistButton({ postSlug, postTitle, postRating, iconOn
       aria-label={currentlySaved ? "Remove from your list" : "Save to your list"}
       aria-pressed={currentlySaved}
     >
-      <span aria-hidden="true" style={{lineHeight:1,display:"inline-block",width:"1em",textAlign:"center"}}>
+      <span aria-hidden="true" className="wishlist-btn__icon">
         {currentlySaved ? (
           <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" fill="currentColor"><path d="M47.6 300.4L228.3 469.1c7.5 7 17.4 10.9 27.7 10.9s20.2-3.9 27.7-10.9L464.4 300.4c30.4-28.3 47.6-68 47.6-109.5v-5.8c0-69.9-50.5-129.5-119.4-141C347 36.5 300.6 51.4 268 84L256 96 244 84c-32.6-32.6-79-47.5-124.6-39.9C50.5 55.6 0 115.2 0 185.1v5.8c0 41.5 17.2 81.2 47.6 109.5z"/></svg>
         ) : (


### PR DESCRIPTION
## Summary
- The icon `<span>` inside `WishlistButton` had four CSS properties set via an inline `style` prop (`lineHeight`, `display`, `width`, `textAlign`), which is a bad pattern in this codebase where styles belong in CSS files
- Moved the four declarations into a new `.wishlist-btn__icon` class in `wishlist-button.css` and replaced the inline prop with `className="wishlist-btn__icon"`

## Category
Bad patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)