### PR TITLE
fix(a11y): improve ARIA associations and landmark regions on review pages

### DIFF
--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -105,12 +105,13 @@ export default function RoastMap({ markers }: Props) {
 
   return (
     <>
-      <p>Also show places that have closed down?</p>
+      <p id="show-closed-desc">Also show places that have closed down?</p>
       <label>
         <input
           type="checkbox"
           checked={showClosed}
           onChange={(e) => setShowClosed(e.target.checked)}
+          aria-describedby="show-closed-desc"
         />
         Show closed places
       </label>
@@ -129,6 +130,9 @@ export default function RoastMap({ markers }: Props) {
         value={minRating}
         onChange={(e) => setMinRating(Number(e.target.value))}
       />
+      <p aria-live="polite" className="sr-only">
+        {visibleMarkers} {visibleMarkers === 1 ? "restaurant" : "restaurants"} shown on map
+      </p>
       <br />
       <br />
       <div

--- a/src/components/share-review-button/share-review-button.astro
+++ b/src/components/share-review-button/share-review-button.astro
@@ -33,8 +33,8 @@ const blueskyUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(sh
 import "./share-review-button.css";
 ---
 
-<div class="share-review-buttons">
-  <p class="share-review-label">Share this review:</p>
+<div class="share-review-buttons" role="region" aria-labelledby="share-heading">
+  <p class="share-review-label" id="share-heading">Share this review:</p>
   <a
     href={whatsappUrl}
     target="_blank"

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -252,8 +252,8 @@ const reviewStructuredData =
     <Newsletter />
     
     {contentType === "post" && isRoastDinner && (
-    <section id="summary" class="summary">
-              <h3>Summary:</h3>
+    <section id="summary" class="summary" aria-labelledby="summary-heading">
+              <h3 id="summary-heading">Summary:</h3>
 
       {(post.closedDowns?.nodes?.length ?? 0) > 0 && (
         <p class="closed-message">
@@ -291,12 +291,12 @@ const reviewStructuredData =
         </p>
       )}
     </section>
-    <section>
-      <h3>Loved & Loathed:</h3>
+    <section aria-labelledby="loved-loathed-heading">
+      <h3 id="loved-loathed-heading">Loved & Loathed:</h3>
       <p>Loved: {post.highlights?.loved}</p>
       <p>Loathed: {post.highlights?.loathed}</p>
     </section>
-    <section>
+    <section aria-label="Share this review">
       <ShareReviewButton
         title={singlePost.title ?? ""}
         rating={rating}
@@ -308,7 +308,7 @@ const reviewStructuredData =
         slug={String(slug)}
       />
     </section>
-    <section>
+    <section aria-label="Get Booking">
       {post.closedDowns?.nodes?.length === 0 && (
         <>
           <h3>Get Booking:</h3>


### PR DESCRIPTION
## Summary

Today's automated quality run (Sunday → Accessibility & SEO category) identified several ARIA and landmark issues across three files. All changes are additive HTML attributes with no visual or behavioural side-effects.

### Changes

**`src/components/roast-map/roast-map.tsx`**
- Added `id="show-closed-desc"` to the descriptive `<p>` paragraph and `aria-describedby="show-closed-desc"` to the checkbox input so screen readers announce the extra context ("Also show places that have closed down?") when the control is focused.
- Added a visually-hidden `aria-live="polite"` paragraph that announces the count of visible map markers (e.g. "12 restaurants shown on map") whenever the checkbox or rating slider filters change. Without this, screen reader users had no feedback that the map had updated.

**`src/components/share-review-button/share-review-button.astro`**
- Added `role="region"` and `aria-labelledby="share-heading"` to the outer `<div>` (and `id="share-heading"` to the existing label paragraph) so the sharing button group becomes a named landmark. Users navigating by landmarks can now jump directly to "Share this review".

**`src/pages/[slug].astro`**
- Added `aria-labelledby="summary-heading"` to the Summary `<section>` (and `id="summary-heading"` to its `<h3>`).
- Added `aria-labelledby="loved-loathed-heading"` to the Loved & Loathed `<section>` (and `id="loved-loathed-heading"` to its `<h3>`).
- Added `aria-label="Share this review"` to the Share section.
- Added `aria-label="Get Booking"` to the Get Booking section.

Without accessible names, multiple sibling `<section>` elements are indistinguishable to assistive technologies. These additions turn them into properly labelled landmark regions.

## Test plan

- [x] All 17 existing tests across `roast-map.test.tsx`, `share-review-button.test.ts`, and `slug.test.ts` pass with no changes required
- [ ] Verify with a screen reader (VoiceOver / NVDA) that the map live region announces filter changes
- [ ] Verify landmark navigation (e.g. rotor in VoiceOver) lists the named review sections on a `/[slug]` page

https://claude.ai/code/session_01GuPpXVo6QDWGM5YnrR3aTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuPpXVo6QDWGM5YnrR3aTR)_