### PR TITLE
chore(types): convert interface to type across components and layouts

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,15 +2,15 @@ declare const Alpine: {
   data: (name: string, callback: () => Record<string, unknown>) => void;
 };
 
-interface ClerkUser {
+type ClerkUser = {
   id: string;
-}
+};
 
-interface ClerkInstance {
+type ClerkInstance = {
   loaded: boolean;
   user: ClerkUser | null | undefined;
   addListener: (callback: () => void) => void;
-}
+};
 
 interface Window {
   Clerk?: ClerkInstance;

--- a/src/components/add-comment/add-comment.astro
+++ b/src/components/add-comment/add-comment.astro
@@ -1,8 +1,8 @@
 ---
-interface Props {
+type Props = {
   postId: string;
   parentId?: string | null;
-}
+};
 const { postId, parentId } = Astro.props as Props;
 
 const message = "";

--- a/src/components/comments/comments.astro
+++ b/src/components/comments/comments.astro
@@ -1,8 +1,8 @@
 ---
-interface Props {
+type Props = {
   threadedComments: CommentsType;
   postId: string;
-}
+};
 
 import type { Comments as CommentsType } from "../../types";
 import Comment from "../comment/comment.astro";

--- a/src/components/dropdown/dropdown.astro
+++ b/src/components/dropdown/dropdown.astro
@@ -4,7 +4,7 @@ type DropdownOption = {
   label: string;
 };
 
-interface Props {
+type Props = {
   label: string;
   id: string;
   name: string;
@@ -16,7 +16,7 @@ interface Props {
   defaultOptionLabel?: string;
   maxOptionLabelLength?: number;
   center?: boolean;
-}
+};
 
 const {
   label,

--- a/src/components/featured-post-header/featured-post-header.astro
+++ b/src/components/featured-post-header/featured-post-header.astro
@@ -1,9 +1,9 @@
 ---
-interface Props {
+type Props = {
   imageSrc: string;
   title: string;
   imageAlt?: string;
-}
+};
 
 const { imageSrc, title, imageAlt = title }: Props = Astro.props;
 ---

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -3,18 +3,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
 // import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 
-interface Marker {
+type Marker = {
   lat: number;
   lng: number;
   label?: string;
   rating: number;
   slug?: string;
   closed?: string;
-}
+};
 
-interface Props {
+type Props = {
   markers: Marker[];
-}
+};
 
 const getMarkerColor = (rating: number): { colour: string; backgroundColour: string } => {
   if (rating >= 9) return { colour: "#fff", backgroundColour: "#4B0082" };

--- a/src/components/social-links/social-links.astro
+++ b/src/components/social-links/social-links.astro
@@ -1,7 +1,7 @@
 ---
-interface Props {
+type Props = {
   className?: string;
-}
+};
 
 const { className = "socials" } = Astro.props;
 ---

--- a/src/components/wishlist-button/wishlist-button.astro
+++ b/src/components/wishlist-button/wishlist-button.astro
@@ -1,9 +1,9 @@
 ---
-interface Props {
+type Props = {
   postSlug: string;
   postTitle: string;
   postRating?: string | null;
-}
+};
 
 const { postSlug, postTitle, postRating } = Astro.props;
 import "./wishlist-button.css";

--- a/src/components/wishlist-button/wishlist-button.tsx
+++ b/src/components/wishlist-button/wishlist-button.tsx
@@ -2,14 +2,14 @@ import { useAuth } from "@clerk/astro/react";
 import { useEffect, useState } from "react";
 import "./wishlist-button.css";
 
-interface Props {
+type Props = {
   postSlug: string;
   postTitle: string;
   postRating?: string | null;
   iconOnly?: boolean;
   isSaved?: boolean;
   onSaveToggle?: (slug: string, nowSaved: boolean) => void;
-}
+};
 
 export default function WishlistButton({ postSlug, postTitle, postRating, iconOnly = false, isSaved, onSaveToggle }: Props) {
   const { isSignedIn, isLoaded } = useAuth();

--- a/src/layouts/TubeLinePageLayout.astro
+++ b/src/layouts/TubeLinePageLayout.astro
@@ -8,14 +8,14 @@ import BaseLayout from "./BaseLayout.astro";
 
 import "../styles/post.css";
 
-interface Props {
+type Props = {
   singlePage: Page;
   lineName: string;
   headingClass: string;
   stations: string[];
   roastPosts: Post[];
   threadedComments: ThreadedComments;
-}
+};
 
 const {
   singlePage,


### PR DESCRIPTION
## Summary

Replaces all non-merging `interface` declarations with `type` aliases, per the project convention of preferring `type` for all type definitions that do not require declaration merging.

- **global.d.ts** — `ClerkUser`, `ClerkInstance` converted to `type`
- **roast-map.tsx** — `Marker`, `Props` converted to `type`
- **wishlist-button.tsx** — `Props` converted to `type`
- **wishlist-button.astro** — `Props` converted to `type`
- **featured-post-header.astro** — `Props` converted to `type`
- **comments.astro** — `Props` converted to `type`
- **dropdown.astro** — `Props` converted to `type`
- **social-links.astro** — `Props` converted to `type`
- **add-comment.astro** — `Props` converted to `type`
- **TubeLinePageLayout.astro** — `Props` converted to `type`

The two `interface Window` declarations (`env.d.ts` and `global.d.ts`) are intentionally left as `interface` — they perform declaration merging/augmentation, which is the one case where `interface` is required.

## Test plan

- [ ] TypeScript build passes (`tsc --noEmit`)
- [ ] Astro build completes without errors
- [ ] No runtime behaviour changes — these are purely type-level declarations

https://claude.ai/code/session_012CqKuDxArqYpFABJ53sogD

---
_Generated by [Claude Code](https://claude.ai/code/session_012CqKuDxArqYpFABJ53sogD)_