### PR TITLE
perf: avoid Leaflet map teardown on filter change; stabilise sort callbacks

### DIFF
--- a/src/components/roast-map/roast-map.test.tsx
+++ b/src/components/roast-map/roast-map.test.tsx
@@ -37,6 +37,15 @@ const leafletMocks = vi.hoisted(() => {
 
   const divIconMock = vi.fn();
 
+  const layerGroupClearLayersMock = vi.fn();
+  const layerGroupAddToMock = vi.fn(function layerGroupAddTo(this: unknown) {
+    return this;
+  });
+  const layerGroupMock = vi.fn(() => ({
+    addTo: layerGroupAddToMock,
+    clearLayers: layerGroupClearLayersMock
+  }));
+
   return {
     mapSetViewMock,
     mapRemoveMock,
@@ -47,7 +56,10 @@ const leafletMocks = vi.hoisted(() => {
     markerBindTooltipMock,
     markerBindPopupMock,
     markerMock,
-    divIconMock
+    divIconMock,
+    layerGroupClearLayersMock,
+    layerGroupAddToMock,
+    layerGroupMock
   };
 });
 
@@ -56,7 +68,8 @@ vi.mock("leaflet", () => ({
     map: leafletMocks.mapMock,
     tileLayer: leafletMocks.tileLayerMock,
     marker: leafletMocks.markerMock,
-    divIcon: leafletMocks.divIconMock
+    divIcon: leafletMocks.divIconMock,
+    layerGroup: leafletMocks.layerGroupMock
   }
 }));
 
@@ -108,6 +121,12 @@ beforeEach(() => {
   leafletMocks.markerMock.mockClear();
   leafletMocks.divIconMock.mockReset();
   leafletMocks.divIconMock.mockImplementation((options: unknown) => ({ options }));
+  leafletMocks.layerGroupMock.mockClear();
+  leafletMocks.layerGroupClearLayersMock.mockReset();
+  leafletMocks.layerGroupAddToMock.mockReset();
+  leafletMocks.layerGroupAddToMock.mockImplementation(function layerGroupAddTo(this: unknown) {
+    return this;
+  });
 });
 
 afterEach(() => {
@@ -184,11 +203,12 @@ describe("roast-map component", () => {
       title: "Closed One (8.6/10)",
       alt: "Closed One (8.6/10)"
     });
-    expect(leafletMocks.mapRemoveMock).toHaveBeenCalledTimes(1);
+    expect(leafletMocks.mapRemoveMock).toHaveBeenCalledTimes(0);
 
     await act(async () => {
       root.unmount();
     });
+    expect(leafletMocks.mapRemoveMock).toHaveBeenCalledTimes(1);
   });
 
   test("filters visible markers by minimum rating", async () => {

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -3,18 +3,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
 // import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 
-interface Marker {
+type Marker = {
   lat: number;
   lng: number;
   label?: string;
   rating: number;
   slug?: string;
   closed?: string;
-}
+};
 
-interface Props {
+type Props = {
   markers: Marker[];
-}
+};
 
 const getMarkerColor = (rating: number): { colour: string; backgroundColour: string } => {
   if (rating >= 9) return { colour: "#fff", backgroundColour: "#4B0082" };
@@ -54,6 +54,8 @@ const createColouredIcon = (colour: string, backgroundColour: string, value: num
 
 export default function RoastMap({ markers }: Props) {
   const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markersLayerRef = useRef<L.LayerGroup | null>(null);
   const [showClosed, setShowClosed] = useState(false);
   const [minRating, setMinRating] = useState(0);
   const filteredMarkers = useMemo(
@@ -73,18 +75,34 @@ export default function RoastMap({ markers }: Props) {
   );
   const totalMarkers = markers.length;
 
+  // Initialise the map and tile layer once on mount.
   useEffect(() => {
     if (!mapRef.current) return;
 
     const map = L.map(mapRef.current).setView([51.505, -0.09], 10);
-
     L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
       attribution: "&copy; OpenStreetMap contributors",
     }).addTo(map);
 
+    const layer = L.layerGroup().addTo(map);
+    mapInstanceRef.current = map;
+    markersLayerRef.current = layer;
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markersLayerRef.current = null;
+    };
+  }, []);
+
+  // Update markers whenever the filtered set changes without recreating the map.
+  useEffect(() => {
+    const layer = markersLayerRef.current;
+    if (!layer) return;
+
+    layer.clearLayers();
 
     filteredMarkers.forEach(({ lat, lng, label, rating, slug }) => {
-
       const { colour, backgroundColour } = getMarkerColor(rating);
       const icon = createColouredIcon(colour, backgroundColour, rating);
       const markerLabel = label ? `${label} (${rating.toFixed(1)}/10)` : `Roast location (${rating.toFixed(1)}/10)`;
@@ -93,14 +111,10 @@ export default function RoastMap({ markers }: Props) {
         title: markerLabel,
         alt: markerLabel,
       })
-        .addTo(map)
+        .addTo(layer)
         .bindTooltip(markerLabel, { direction: "top", opacity: 0.9 })
         .bindPopup(`<a href="/${slug}">${label}</a> - ${rating}/10`);
     });
-
-    return () => {
-      map.remove();
-    };
   }, [filteredMarkers]);
 
   return (

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -218,27 +218,32 @@ export const useSortFilter = (posts: Post[]) => {
   }, []);
   const [showInflationPrice, setShowInflationPrice] = useState(false);
 
-  const handleCheckboxChange = (setter: BooleanStateSetter): (() => void) => () => {
-    setter((prev) => !prev);
-  };
+  const handleCheckboxChange = useCallback(
+    (setter: BooleanStateSetter): (() => void) =>
+      () => {
+        setter((prev) => !prev);
+      },
+    []
+  );
 
-  const handleSortChange = (e: ChangeEvent<HTMLSelectElement>) => {
+  const handleSortChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
     setSortColumn(e.target.value);
-  };
+  }, []);
 
-  const toggleSortOrder = (): void => {
+  const toggleSortOrder = useCallback((): void => {
     setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
-  };
+  }, []);
 
-  const handleFilterChange = (
-    e: ChangeEvent<HTMLSelectElement> | ChangeEvent<HTMLInputElement>
-  ) => {
-    dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
-  };
+  const handleFilterChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement> | ChangeEvent<HTMLInputElement>) => {
+      dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
+    },
+    []
+  );
 
-  const clearFilters = (): void => {
+  const clearFilters = useCallback((): void => {
     dispatch({ type: "CLEAR_FILTERS" });
-  };
+  }, []);
 
   const sortedPosts = useMemo(
     () => sortedByColumn(filterPosts(posts, filters), sortColumn, sortOrder),


### PR DESCRIPTION
## Summary

**Wednesday performance audit** — two React component optimisations.

### `roast-map.tsx` — stop destroying the map on every filter change

Previously a single `useEffect([filteredMarkers])` recreated the entire Leaflet map (DOM container, tile layer, event listeners, network requests for tiles) every time the user toggled "show closed" or dragged the minimum-rating slider. This is expensive: Leaflet map initialisation involves layout, multiple DOM operations, and fresh tile fetches.

Fix: split into two effects:
- **mount effect** (`[]`) — creates the map and tile layer once, stores refs to the `L.Map` and a `L.LayerGroup`.
- **markers effect** (`[filteredMarkers]`) — calls `layer.clearLayers()` then re-adds only the marker set, leaving the base map untouched.

Users interacting with the filter controls will see instant marker updates instead of a full map flash/reload.

Also converted `interface` → `type` for `Marker` and `Props` to match project style.

### `useSortFilter.tsx` — wrap event handlers in `useCallback`

`handleCheckboxChange`, `handleSortChange`, `toggleSortOrder`, `handleFilterChange`, and `clearFilters` were recreated as new function references on every render. Wrapped them in `useCallback` with stable dependency arrays (all use only stable setters/dispatch), matching the existing treatment of `copyShareableLink`. Prevents unnecessary downstream work if the component or its children are ever memoised.

## Test plan

- [ ] Visit `/maps` — map loads correctly with all markers
- [ ] Toggle "Show closed places" — markers update without the map flashing or re-loading tiles
- [ ] Drag the minimum-rating slider — markers update incrementally, map viewport and zoom are preserved
- [ ] Visit `/league-of-roasts` — table loads and sorts correctly
- [ ] Use sort, filter, and clear-filters controls — all work as before

https://claude.ai/code/session_01Bk3GV52RxknR1eC1zVhQsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk3GV52RxknR1eC1zVhQsV)_