### PR TITLE
fix: restore dark colour to navbar

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -10,7 +10,7 @@ header {
   align-items: center;
   justify-content: center;
   width: 100%;
-  background-color: var(--roast-new-blue);
+  background-color: var(--roast-main-text);
   color: var(--roast-white);
   font-size: 1.5em;
   margin-right: 2rem;
@@ -132,7 +132,7 @@ header {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   z-index: 1000;
   width: 100%;
-  background-color: var(--roast-new-blue);
+  background-color: var(--roast-main-text);
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s ease;
@@ -195,7 +195,7 @@ header {
   left: 0;
   min-width: 200px;
   z-index: 1001;
-  background-color: var(--roast-new-blue);
+  background-color: var(--roast-main-text);
 }
 
 .dropdown-menu a {


### PR DESCRIPTION
## Summary

- Navbar, mobile menu, and dropdown backgrounds were using `var(--roast-new-blue)` (#0129ad, blue) instead of the intended dark colour
- Reverts all three to `var(--roast-main-text)` (#403b37, dark brown) which was the original colour before being inadvertently changed in the dark mode fixes commit

## Test plan
- [ ] Navbar background is dark brown, not blue
- [ ] Mobile hamburger menu background is dark brown
- [ ] Dropdown menus background is dark brown
- [ ] White text on navbar remains readable
- [ ] Hover states (pink) still work correctly