### PR TITLE
Remove dead preferred-locations feature code from index.astro

### DIFF
--- a/src/pages/api/wishlist.test.ts
+++ b/src/pages/api/wishlist.test.ts
@@ -1,0 +1,116 @@
+import type { APIContext } from "astro";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../lib/db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+import { db } from "../../lib/db";
+import { GET, POST } from "./wishlist";
+
+function makeContext(clerkId: string | null, body?: Record<string, unknown>): APIContext {
+  return {
+    locals: { auth: () => ({ userId: clerkId }) },
+    request: { json: () => Promise.resolve(body ?? {}) },
+  } as unknown as APIContext;
+}
+
+function makeSelectChain(result: unknown[] = []) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+    orderBy: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("GET /api/wishlist", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("returns 401 when unauthenticated", async () => {
+    const response = await GET(makeContext(null));
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Unauthorized");
+  });
+
+  test("returns empty array when user is not found in the database", async () => {
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([]) as never);
+    const response = await GET(makeContext("clerk_abc"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
+  });
+
+  test("returns wishlist items for the authenticated user", async () => {
+    const items = [
+      { id: "item-1", postSlug: "roast-one", postTitle: "Roast One", postRating: "8.5" },
+    ];
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-uuid" }]) as never)
+      .mockReturnValueOnce(makeSelectChain(items) as never);
+    const response = await GET(makeContext("clerk_abc"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(items);
+  });
+});
+
+describe("POST /api/wishlist", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("returns 401 when unauthenticated", async () => {
+    const response = await POST(makeContext(null, { postSlug: "slug", postTitle: "Title" }));
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Unauthorized");
+  });
+
+  test("returns 400 when postSlug is missing", async () => {
+    const response = await POST(makeContext("clerk_abc", { postTitle: "Title" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("required");
+  });
+
+  test("returns 400 when postTitle is missing", async () => {
+    const response = await POST(makeContext("clerk_abc", { postSlug: "slug" }));
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("required");
+  });
+
+  test("returns 200 when the wishlist item already exists", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-uuid" }]) as never)
+      .mockReturnValueOnce(makeSelectChain([{ id: "existing-item" }]) as never);
+    const response = await POST(makeContext("clerk_abc", { postSlug: "slug", postTitle: "Title" }));
+    expect(response.status).toBe(200);
+    expect((await response.json()).saved).toBe(true);
+  });
+
+  test("inserts a new wishlist item and returns 201", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-uuid" }]) as never)
+      .mockReturnValueOnce(makeSelectChain([]) as never);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    const response = await POST(makeContext("clerk_abc", { postSlug: "slug", postTitle: "Title", postRating: "9.0" }));
+    expect(response.status).toBe(201);
+    expect((await response.json()).saved).toBe(true);
+  });
+
+  test("creates a user record when the user is not found, then saves the item", async () => {
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([]) as never);
+    vi.mocked(db.insert)
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "new-user-id" }]),
+        }),
+      } as never)
+      .mockReturnValueOnce({
+        values: vi.fn().mockResolvedValue(undefined),
+      } as never);
+    const response = await POST(makeContext("clerk_abc", { postSlug: "slug", postTitle: "Title" }));
+    expect(response.status).toBe(201);
+    expect((await response.json()).saved).toBe(true);
+  });
+});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,11 +10,10 @@ export const prerender = true;
 import GET_BEST_ROASTS from "../lib/queries/bestRoasts";
 import GET_ALL_PAGES from "../lib/queries/getAllPages";
 import GET_FEATURE_POSTS from "../lib/queries/getFeaturePosts.ts";
-import GET_LOCATIONS from "../lib/queries/getLocations";
 import MOST_RECENT_POST_QUERY from "../lib/queries/mostRecentPost";
 import OTHER_POSTS_AFTER_FIRST_QUERY from "../lib/queries/otherPostsAfterFirst";
 import SINGLE_PAGE_QUERY_PREVIEW from "../lib/queries/singlePage";
-import type { Location, Page, Post, Size } from "../types";
+import type { Page, Post, Size } from "../types";
 
 type PostWithFeaturedImage = Post & { featuredImage: string };
 type PageWithFeaturedImage = Page & { featuredImage: string };
@@ -123,25 +122,6 @@ try {
       };
     })
     .filter(Boolean) as PageWithFeaturedImage[];
-} catch (error) {
-  console.error("Error fetching location pages:", error);
-}
-
-const allLocations: Location[] = [];
-
-try {
-  const locations = (await fetchGraphQL(GET_LOCATIONS)) as {
-    areas: { nodes: Location[] };
-    boroughs: { nodes: Location[] };
-  };
-
-  if (locations?.areas?.nodes) {
-    allLocations.push(...locations.areas.nodes);
-  }
-
-  if (locations?.boroughs?.nodes) {
-    allLocations.push(...locations.boroughs.nodes);
-  }
 } catch (error) {
   console.error("Error fetching location pages:", error);
 }
@@ -340,36 +320,6 @@ try {
       }
     </ul>
   </section>
-  <!-- <section class="home-list preferred-locations">
-    <p>
-      Select your preferred location from the list below and we'll highlight appropriate reviews to
-      you in the future.
-    </p>
-
-    <div class="custom-select">
-      <button class="dropdown-btn" id="dropdown-btn">Select Locations</button>
-      <div class="dropdown-content">
-        {
-          allLocations.map((location) => (
-            <label class="dropdown-item">
-              <input
-                type="checkbox"
-                value={location.slug}
-                class="hidden-checkbox location-checkbox"
-                data-location={location.slug}
-              />
-              <span>{location.name}</span>
-            </label>
-          ))
-        }
-      </div>
-    </div>
-    <div id="selected-locations">
-      <p>Your selected locations:</p>
-      <ul id="selected-locations-list"></ul>
-    </div>
-  </section> -->
-
   <section class="home">
     <h2>Search:</h2>
     <Search resultLimit={4} />
@@ -464,80 +414,6 @@ try {
     </ul>
   </section>
   <Newsletter />
-  <script lang="ts">
-    document.addEventListener("DOMContentLoaded", function () {
-      const dropdownButton = document.getElementById("dropdown-btn");
-      const dropdownContent = document.querySelector(".dropdown-content");
-      const locationCheckboxes =
-        document.querySelectorAll(".location-checkbox");
-      const selectedLocationsList = document.getElementById(
-        "selected-locations-list"
-      );
-
-      const savedLocations =
-        JSON.parse(localStorage.getItem("selectedLocations") || "[]") || [];
-      locationCheckboxes.forEach((checkbox) => {
-        if (savedLocations.includes(checkbox.value)) {
-          checkbox.checked = true;
-        }
-      });
-
-      const capitaliseAndRemoveHyphen = (string) => {
-        return string
-          .split("-")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" ");
-      };
-
-      displaySelectedLocations(savedLocations);
-
-      if (dropdownButton) {
-        dropdownButton.addEventListener("click", function () {
-          if (dropdownContent) {
-            dropdownContent.classList.toggle("open");
-          }
-        });
-      }
-
-      locationCheckboxes.forEach((checkbox) => {
-        checkbox.addEventListener("change", function () {
-          updateSelectedLocations();
-        });
-      });
-
-      function updateSelectedLocations() {
-        const selectedLocations = Array.from(locationCheckboxes)
-          .filter((checkbox) => checkbox.checked)
-          .map((checkbox) => checkbox.value);
-
-        localStorage.setItem(
-          "selectedLocations",
-          JSON.stringify(selectedLocations)
-        );
-
-        displaySelectedLocations(selectedLocations);
-      }
-
-      function displaySelectedLocations(locations) {
-        if (selectedLocationsList) {
-          selectedLocationsList.innerHTML = "";
-        }
-        if (locations.length === 0) {
-          if (selectedLocationsList) {
-            selectedLocationsList.innerHTML = "<li>No locations selected</li>";
-          }
-        } else {
-          locations.forEach((location) => {
-            const listItem = document.createElement("li");
-            listItem.textContent = capitaliseAndRemoveHyphen(location);
-            if (selectedLocationsList) {
-              selectedLocationsList.appendChild(listItem);
-            }
-          });
-        }
-      }
-    });
-  </script>
   <script>
     const lastVisit = localStorage.getItem("lastVisit");
     const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- Removed `GET_LOCATIONS` GraphQL import and the `allLocations` fetch block — a build-time API call that was fetching data used nowhere in the rendered output
- Removed `Location` from the type import (unused after the above)
- Removed the commented-out `<!-- <section class="home-list preferred-locations"> -->` HTML block
- Removed the 73-line `<script lang="ts">` block that wired up DOM event listeners for `#dropdown-btn`, `.location-checkbox`, and `#selected-locations-list` — elements that no longer exist in the DOM, so the script executed on every page load and silently no-oped

The preferred-locations feature had been commented out at the HTML level but all its supporting code (import, data fetch, client script) was left behind.

## Category
Dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)