### PR TITLE
Replace unsafe filterState cast with type predicate guard

### DIFF
--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -29,6 +29,8 @@ const initialFilterState: FilterState = {
   zone: "",
 };
 
+const isFilterKey = (key: string): key is keyof FilterState => key in initialFilterState;
+
 const filterReducer = (state: FilterState, action: FilterAction): FilterState => {
   switch (action.type) {
     case "SET_FILTER":
@@ -236,7 +238,10 @@ export const useSortFilter = (posts: Post[]) => {
 
   const handleFilterChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement> | ChangeEvent<HTMLInputElement>) => {
-      dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
+      const { name, value } = e.target;
+      if (isFilterKey(name)) {
+        dispatch({ type: "SET_FILTER", name, value });
+      }
     },
     []
   );


### PR DESCRIPTION
## Summary
- `handleFilterChange` in `useSortFilter.tsx` was casting `e.target.name as keyof FilterState` — an unsound assertion that silently accepts any DOM string as a valid filter key, risking silent state corruption if a form element ever has an unexpected `name` attribute
- Introduced `isFilterKey`, a type predicate (`key is keyof FilterState`) backed by a runtime `in` check against `initialFilterState`, so the type is properly narrowed without an unsafe cast
- The `as keyof FilterState` assertion inside `handleFilterChange` is now gone; the type predicate does the narrowing correctly

## Category
Strict typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPGSAFsdghbw1CVZrgXxFG)_