### PR TITLE
chore(typescript): replace any and loose string types with precise types

### DIFF
--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -1,6 +1,9 @@
 import { type ChangeEvent, type ReactElement, type SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import type { Post } from "../../types";
 
+type SortColumn = "rating" | "price" | "yearVisited" | "meat" | "tubeStation" | "area" | "borough" | "owner" | "closedDown" | "title";
+type SortOrder = "asc" | "desc";
+
 type FilterState = {
   meat: string;
   score: string;
@@ -38,7 +41,7 @@ const filterReducer = (state: FilterState, action: FilterAction): FilterState =>
   }
 };
 
-const sortedByColumn = (posts: Post[], column: string, order: string): Post[] => {
+const sortedByColumn = (posts: Post[], column: SortColumn, order: SortOrder): Post[] => {
   return [...posts].sort((a, b) => {
     let aValue: string | number = "";
     let bValue: string | number = "";
@@ -175,8 +178,8 @@ const getInitialStateFromUrl = (): URLSearchParams | null => {
 export const useSortFilter = (posts: Post[]) => {
   const urlParams = getInitialStateFromUrl();
 
-  const [sortOrder, setSortOrder] = useState(urlParams?.get("order") ?? "desc");
-  const [sortColumn, setSortColumn] = useState(urlParams?.get("sort") ?? "rating");
+  const [sortOrder, setSortOrder] = useState<SortOrder>((urlParams?.get("order") ?? "desc") as SortOrder);
+  const [sortColumn, setSortColumn] = useState<SortColumn>((urlParams?.get("sort") ?? "rating") as SortColumn);
   const [filters, dispatch] = useReducer(filterReducer, {
     meat: urlParams?.get("meat") ?? "",
     score: urlParams?.get("score") ?? "",
@@ -227,7 +230,7 @@ export const useSortFilter = (posts: Post[]) => {
   );
 
   const handleSortChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-    setSortColumn(e.target.value);
+    setSortColumn(e.target.value as SortColumn);
   }, []);
 
   const toggleSortOrder = useCallback((): void => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,8 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const normalizePathname = (value: string) => (value.endsWith("/") ? value : `${value}/`);
 
-const assertSeoBasics = async (page: { title: () => Promise<string>; url: () => string; locator: (selector: string) => any }, expectedPathname: string) => {
+const assertSeoBasics = async (page: Page, expectedPathname: string) => {
   const title = (await page.title()).trim();
   expect(title.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

- **Remove `any` from E2E smoke test**: the `assertSeoBasics` helper used a hand-rolled inline type with `locator: (selector: string) => any`. Replaced with `Page` imported directly from `@playwright/test`, which is the actual type being passed.
- **Add `SortColumn` and `SortOrder` union types to `useSortFilter`**: `sortedByColumn` previously accepted `column: string` and `order: string`, allowing any string to be passed silently. The new union types (`"rating" | "price" | ...` and `"asc" | "desc"`) narrow the state and function signatures, making invalid sort columns and orders a compile-time error.

## What wasn't changed

- `global.d.ts` and `env.d.ts` both use `interface Window` — kept as-is since Window augmentation requires declaration merging, which only works with `interface`.
- `src/lib/fetchAllSlugs.ts` retains its `as SlugsResponse` cast — switching to the generic parameter triggered a spurious `TS7022` initializer cycle error from the TypeScript compiler, so the cast form is safer here.

## Test plan

- [ ] `tsc --noEmit` passes (verified locally — 0 errors)
- [ ] All 345 unit tests pass (verified locally)
- [ ] No E2E test logic changed, only the parameter type of the shared helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171PucrUYaBi9dKxU17XuuT

---
_Generated by [Claude Code](https://claude.ai/code/session_0171PucrUYaBi9dKxU17XuuT)_