### PR TITLE
feat: scored search results (#436)

### DIFF
--- a/src/components/search/search.astro
+++ b/src/components/search/search.astro
@@ -29,6 +29,24 @@ const { resultLimit = 4 } = Astro.props;
               <a :href="`/${post.slug}`" x-text="post.title"></a>
             </h3>
 
+            <div class="search-result-meta">
+              <span
+                class="score-chip"
+                x-show="post.ratings?.nodes[0]?.name"
+                :style="post.ratings?.nodes[0]?.name ? `background-color: ${getScoreColor(post.ratings.nodes[0].name).background}; color: ${getScoreColor(post.ratings.nodes[0].name).color}` : ''"
+                x-text="post.ratings?.nodes[0]?.name ? parseFloat(post.ratings.nodes[0].name).toFixed(1) : ''"
+              ></span>
+              <span
+                class="area-label"
+                x-show="post.areas?.nodes[0]?.name"
+                x-text="post.areas?.nodes[0]?.name"
+              ></span>
+              <span
+                class="closed-badge"
+                x-show="post.closedDowns?.nodes?.length > 0"
+              >Closed</span>
+            </div>
+
             <a
               :href="`/${post.slug}`"
               rel="noopener noreferrer"
@@ -64,6 +82,22 @@ const { resultLimit = 4 } = Astro.props;
         this.resultLimit = Number(limit) || 4;
       },
 
+      getScoreColor(scoreStr) {
+        const score = parseFloat(scoreStr);
+        if (isNaN(score)) return { color: "#fff", background: "#000000" };
+        if (score >= 9) return { color: "#fff", background: "#4B0082" };
+        if (score >= 8.5) return { color: "#fff", background: "#83539B" };
+        if (score >= 8) return { color: "#fff", background: "#588EB5" };
+        if (score >= 7.5) return { color: "#000", background: "#51A790" };
+        if (score >= 7) return { color: "#000", background: "#4D7833" };
+        if (score >= 6.5) return { color: "#000", background: "#6A972A" };
+        if (score >= 6) return { color: "#000", background: "#CFB920" };
+        if (score >= 5) return { color: "#fff", background: "#CF7C1D" };
+        if (score >= 4) return { color: "#fff", background: "#FF0000" };
+        if (score >= 3) return { color: "#fff", background: "#8B0000" };
+        return { color: "#fff", background: "#000000" };
+      },
+
       async handleSearch() {
         const response = await fetch(GRAPHQL_URL, {
           method: "POST",
@@ -72,13 +106,18 @@ const { resultLimit = 4 } = Astro.props;
             query: `
               query SearchPosts($search: String!, $first: Int!) {
                 posts(where: { search: $search }, first: $first) {
-                  nodes { title
-                  slug
-                  featuredImage {
-                    node {
-                      sourceUrl
+                  nodes {
+                    title
+                    slug
+                    featuredImage {
+                      node {
+                        sourceUrl
+                      }
                     }
-                  } }
+                    ratings { nodes { name } }
+                    areas { nodes { name } }
+                    closedDowns { nodes { name } }
+                  }
                 }
               }
             `,

--- a/src/components/search/search.test.ts
+++ b/src/components/search/search.test.ts
@@ -27,5 +27,20 @@ describe("search component", () => {
     expect(html).toContain("search: this.searchTerm");
     expect(html).toContain("first: this.resultLimit");
     expect(html).toContain("this.searchPerformed = true");
+    expect(html).toContain("ratings { nodes { name } }");
+    expect(html).toContain("areas { nodes { name } }");
+    expect(html).toContain("closedDowns { nodes { name } }");
+  });
+
+  test("renders score chip, area label, and closed badge elements", async () => {
+    const container = await AstroContainer.create();
+    const { default: Search } = await import("./search.astro");
+    const html = await container.renderToString(Search);
+
+    expect(html).toContain('class="score-chip"');
+    expect(html).toContain('class="area-label"');
+    expect(html).toContain('class="closed-badge"');
+    expect(html).toContain("getScoreColor");
+    expect(html).toContain("post.closedDowns?.nodes?.length > 0");
   });
 });

--- a/src/styles/search-page.css
+++ b/src/styles/search-page.css
@@ -12,6 +12,37 @@
     margin-bottom: 20px;
   }
 
+  .search-result-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 0 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .score-chip {
+    display: inline-block;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.9rem;
+  }
+
+  .area-label {
+    font-size: 0.85rem;
+    color: #555;
+  }
+
+  .closed-badge {
+    display: inline-block;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    background-color: #888;
+    color: #fff;
+    font-size: 0.8rem;
+    font-weight: bold;
+  }
+
   form {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary

- Extends the GraphQL query in `search.astro` to fetch `ratings`, `areas`, and `closedDowns` alongside each result (no new API calls)
- Renders a colour-coded score chip (same colour bands as the Leaflet map), an area label, and a grey "Closed" badge on each search result card
- Adds `getScoreColor()` helper to the Alpine component, mirroring the logic from `roast-map.tsx`
- Adds CSS for the new elements to `search-page.css`
- Adds 2 new tests covering the GraphQL field additions and new DOM elements

Closes #436

## Test plan

- [ ] Search for a term (e.g. "Hackney") and confirm score chip, area, and (where applicable) Closed badge appear on each card
- [ ] Confirm chip colours match the map markers for the same pubs
- [ ] Confirm results without a rating/area/closed status show no empty chip/label
- [ ] Run `yarn test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)