### PR TITLE
chore: fix Biome 2.5 compat — pin noImportantStyles as warn

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -45,7 +45,8 @@
         "noUselessElse": "error"
       },
       "complexity": {
-        "noForEach": "off"
+        "noForEach": "off",
+        "noImportantStyles": "warn"
       }
     }
   },

--- a/src/styles/search-page.css
+++ b/src/styles/search-page.css
@@ -55,9 +55,8 @@
 
     input,
     button {
-      margin: 10px;
+      margin: 10px 10px 10px 0;
       width: 200px;
-      margin-left: 0 !important;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Updates `biome.json` `$schema` from `2.4.13` → `2.4.16` (removes the schema version mismatch info on every lint run)
- Explicitly sets `noImportantStyles: "warn"` in the complexity rules so it stays a warning when Biome 2.5.0 lands via Renovate PR #454 (which would otherwise promote it to an error and fail CI)
- Removes the one unnecessary `!important` from `src/styles/search-page.css` (the `!important` declarations in `header.css` are legitimate Clerk overrides and are kept)

## Why CI was passing locally but failing on PR #454

PR #454 bumps `@biomejs/biome` from `2.4.16` → `2.5.0`. Biome 2.5.0 promotes `noImportantStyles` from a warning to an error in the recommended ruleset. Locally (still on 2.4.16) it was only ever a warning, so `yarn lint` exited 0. On CI with 2.5.0 it became an error, causing lint to fail.

This PR should be merged before PR #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)