### PR TITLE
Gate My Roast List homepage item behind authFeatures feature flag

### DIFF
--- a/src/components/my-roast-list-item/MyRoastListItem.tsx
+++ b/src/components/my-roast-list-item/MyRoastListItem.tsx
@@ -1,0 +1,32 @@
+import { memo, useEffect, useState } from "react";
+
+function useAuthFlag(): boolean | null {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
+    const val = match ? match[2] : null;
+    setEnabled(val === null ? false : val === "true");
+  }, []);
+  return enabled;
+}
+
+type MyRoastListItemProps = {
+  imgSrc: string;
+};
+
+export const MyRoastListItem = memo(function MyRoastListItem({ imgSrc }: MyRoastListItemProps) {
+  const enabled = useAuthFlag();
+  if (!enabled) return null;
+  return (
+    <li className="heading">
+      <h3>
+        <a href="/my-roasts" rel="noopener noreferrer">
+          My Roast List
+        </a>
+      </h3>
+      <a href="/my-roasts" rel="noopener noreferrer" className="featured-image">
+        <img src={imgSrc} alt="My roast list" width="400" height="300" loading="lazy" />
+      </a>
+    </li>
+  );
+});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/index.css";
+import { MyRoastListItem } from "../components/my-roast-list-item/MyRoastListItem";
 import Newsletter from "../components/newsletter/newsletter.astro";
 import NewsletterPopup from "../components/newsletter-popup/newsletter-popup.astro";
 import Search from "../components/search/search.astro";
-import { MyRoastListItem } from "../components/my-roast-list-item/MyRoastListItem";
 import { fetchGraphQL } from "../lib/api";
 
 export const prerender = true;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -329,7 +329,7 @@ try {
           <img src={findARoastImg.src} alt="Find a roast" width="400" height="300" loading="lazy" />
         </a>
       </li>
-      <MyRoastListItem imgSrc={dreamingOfRoastDinners.src} client:only="react" />
+      <MyRoastListItem imgSrc={dreamingOfRoastDinners.src} client:load />
       <li class="heading">
         <h3><a href="/guessthescore" rel="noopener noreferrer">Guess The Score</a></h3>
         <a href="/guessthescore" rel="noopener noreferrer" class="featured-image">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import "../styles/index.css";
 import Newsletter from "../components/newsletter/newsletter.astro";
 import NewsletterPopup from "../components/newsletter-popup/newsletter-popup.astro";
 import Search from "../components/search/search.astro";
+import { MyRoastListItem } from "../components/my-roast-list-item/MyRoastListItem";
 import { fetchGraphQL } from "../lib/api";
 
 export const prerender = true;
@@ -328,12 +329,7 @@ try {
           <img src={findARoastImg.src} alt="Find a roast" width="400" height="300" loading="lazy" />
         </a>
       </li>
-      <li class="heading">
-        <h3><a href="/my-roasts" rel="noopener noreferrer">My Roast List</a></h3>
-        <a href="/my-roasts" rel="noopener noreferrer" class="featured-image">
-          <img src={dreamingOfRoastDinners.src} alt="My roast list" width="400" height="300" loading="lazy" />
-        </a>
-      </li>
+      <MyRoastListItem imgSrc={dreamingOfRoastDinners.src} client:only="react" />
       <li class="heading">
         <h3><a href="/guessthescore" rel="noopener noreferrer">Guess The Score</a></h3>
         <a href="/guessthescore" rel="noopener noreferrer" class="featured-image">

--- a/src/pages/index.test.ts
+++ b/src/pages/index.test.ts
@@ -8,6 +8,10 @@ vi.mock("../components/header/HeaderAuth", () => ({
   HeaderAuthMobile: Object.assign(() => "", { isAstroComponentFactory: true }),
 }));
 
+vi.mock("../components/my-roast-list-item/MyRoastListItem", () => ({
+  MyRoastListItem: Object.assign(() => "", { isAstroComponentFactory: true }),
+}));
+
 vi.mock("../lib/api", () => ({
   fetchGraphQL: fetchGraphQLMock,
 }));


### PR DESCRIPTION
## Summary

- Replaces the static "My Roast List" `<li>` on the homepage with a `MyRoastListItem` React component
- The component reads the `flag_authFeatures` cookie client-side and renders `null` when the flag is off, matching the same pattern used by `HeaderAuth.tsx`
- Uses `client:only="react"` since the homepage is prerendered

## Test plan

- [ ] Enable the `authFeatures` flag via `/flags` — My Roast List tile should appear on the homepage
- [ ] Disable the flag — My Roast List tile should not appear
- [ ] Verify Find A Roast and Guess The Score tiles are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)