### PR TITLE
fix(a11y/seo): improve accessibility and add missing meta descriptions

### DIFF
--- a/src/components/add-comment/add-comment.astro
+++ b/src/components/add-comment/add-comment.astro
@@ -27,7 +27,7 @@ const messageColor = "black";
     <textarea name="commentText" id={`commentText-${parentId}`} required></textarea>
   </div>
   <button class="reply-button" data-button-id={parentId}>Post Reply</button>
-  <p style={`color: ${messageColor};`}>{message}</p>
+  <p role="status" aria-live="polite" aria-atomic="true" style={`color: ${messageColor};`}>{message}</p>
 </form>
 
 <script is:inline define:vars={{ GRAPHQL_URL: import.meta.env.PUBLIC_GRAPHQL_URL }}>

--- a/src/components/comment/comment.astro
+++ b/src/components/comment/comment.astro
@@ -73,6 +73,7 @@ const formatDate = (dateString: string): string => {
   <div
     class="reply-form-container"
     id={`reply-form-${comment.id}`}
+    aria-hidden="true"
     style="display: none;"
   >
     <AddComment postId={postId} parentId={comment.id} />
@@ -116,6 +117,7 @@ const formatDate = (dateString: string): string => {
           if (formContainer) {
             const isVisible = formContainer.style.display !== "none";
             formContainer.style.display = isVisible ? "none" : "block";
+            formContainer.setAttribute("aria-hidden", isVisible.toString());
             event.target.setAttribute("aria-expanded", (!isVisible).toString());
           }
         });

--- a/src/components/comments/comments.astro
+++ b/src/components/comments/comments.astro
@@ -39,7 +39,7 @@ const { threadedComments, postId } = Astro.props as Props;
       <textarea id="commentText" name="commentText" required></textarea>
     </div>
     <button type="submit">Post Comment</button>
-    <p id="message"></p>
+    <p id="message" role="status" aria-live="polite" aria-atomic="true"></p>
   </form>
 </section>
 

--- a/src/components/newsletter-popup/newsletter-popup.astro
+++ b/src/components/newsletter-popup/newsletter-popup.astro
@@ -13,7 +13,6 @@ import "./newsletter-popup.css";
       width="480"
       height="320"
       style="border: 1px solid #EEE; background: white"
-      frameborder="0"
       scrolling="no"
       title="Subscribe to the Roast Dinners in London newsletter"
     ></iframe>

--- a/src/components/newsletter/newsletter.astro
+++ b/src/components/newsletter/newsletter.astro
@@ -5,7 +5,6 @@
     width="480"
     height="320"
     style="border: 1px solid #EEE; background: white"
-    frameborder="0"
     scrolling="no"
     title="Subscribe to the Roast Dinners in London newsletter"
   ></iframe>

--- a/src/components/share-review-button/share-review-button.astro
+++ b/src/components/share-review-button/share-review-button.astro
@@ -75,6 +75,7 @@ import "./share-review-button.css";
     type="button"
     class="share-review-btn"
     id="copy-review-btn"
+    aria-label={`Copy ${title} review text to clipboard`}
   >
     Copy text
   </button>
@@ -87,9 +88,11 @@ import "./share-review-button.css";
       try {
         await navigator.clipboard.writeText(shareText);
         btn.textContent = "Copied!";
+        btn.setAttribute("aria-label", "Review text copied to clipboard");
         btn.classList.add("share-review-btn--copied");
         setTimeout(() => {
           btn.textContent = "Copy text";
+          btn.setAttribute("aria-label", "Copy review text to clipboard");
           btn.classList.remove("share-review-btn--copied");
         }, 2000);
       } catch {

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -39,7 +39,10 @@ try {
 }
 ---
 
-<BaseLayout pageTitle="Archive">
+<BaseLayout
+  pageTitle="Archive"
+  description="Browse every roast dinner review by month. Search the complete Roast Dinners in London archive going back to 2016."
+>
   <div class="no-image-container">
     <section class="post-title">
       <h2>Gravy Archives</h2>

--- a/src/pages/chains/index.astro
+++ b/src/pages/chains/index.astro
@@ -43,7 +43,10 @@ const chainOptions = sortedChains.map((chain) => ({
 }));
 ---
 
-<BaseLayout pageTitle="Chains">
+<BaseLayout
+  pageTitle="Chains"
+  description="Browse roast dinner reviews by restaurant chain. Find every review for your favourite chain in London."
+>
   <div class="no-image-container">
     <section class="post-title">
       <h2>Chains</h2>

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -6,7 +6,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import "./sign-in.css";
 ---
 
-<BaseLayout pageTitle="Sign In">
+<BaseLayout
+  pageTitle="Sign In"
+  description="Sign in to your Roast Dinners in London account to manage your wishlist and roast list."
+>
   <div class="sign-in-container">
     <ClerkSignIn />
   </div>


### PR DESCRIPTION
## Summary

Thursday's scheduled accessibility & SEO pass. Fixes 8 issues across 9 files.

### Accessibility

- **`aria-live` on form status messages** (`comments.astro`, `add-comment.astro`): Added `role="status" aria-live="polite" aria-atomic="true"` to the `<p>` elements that display submission success/failure. Without this, screen readers never announce the result of posting a comment or reply.

- **`aria-label` on copy-review button** (`share-review-button.astro`): The clipboard copy button had no accessible name. Added a descriptive `aria-label` at render time, and the JS now updates it to "Review text copied to clipboard" while in the copied state, then resets it — so assistive tech users know exactly what happened.

- **`aria-hidden` on reply form containers** (`comment.astro`): Reply forms use `display: none` to toggle visibility, but the accessibility tree still exposed them. Added `aria-hidden="true"` on the container initially, and the click handler now keeps `aria-hidden` in sync with `aria-expanded` on the toggle button.

### SEO

- **Meta descriptions on three pages**: `archive.astro`, `chains/index.astro`, and `sign-in.astro` were all calling `<BaseLayout>` without a `description` prop, so every social share and search snippet fell back to the generic site tagline. Each now has a specific, relevant description.

- **Remove deprecated `frameborder="0"`** (`newsletter.astro`, `newsletter-popup.astro`): `frameborder` is a deprecated presentational attribute; the border is already controlled by the inline `style` attribute on both iframes.

## Test plan

- [ ] Post a comment on a review page with VoiceOver/NVDA enabled — confirm success/failure message is announced
- [ ] Click "Copy text" on a review's share buttons — confirm screen reader announces the state change
- [ ] Click "Reply" on a comment — confirm the reply form appears/disappears correctly and `aria-expanded` matches visibility
- [ ] Check `<meta name="description">` in source for `/archive`, `/chains`, and `/sign-in`
- [ ] Confirm Substack iframes still render correctly (border remains, no visual change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMgaSg6rGUq9BtTtfRa39e

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMgaSg6rGUq9BtTtfRa39e)_