### PR TITLE
Add HTTP security headers to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    },
+    {
       "source": "/~partytown/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary

- Adds a global header block to `vercel.json` covering all routes
- Headers added: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`
- Addresses OWASP A05:2021 (Security Misconfiguration) findings from issue #441

## Test plan

- [ ] Deploy to Vercel preview and check response headers include the new security headers
- [ ] Confirm existing caching headers on `/~partytown/`, `/fonts/`, `/_astro/`, and `/404.html` routes still work

Closes #441