### PR TITLE
security: sanitize all WordPress content rendered via set:html

### DIFF
--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeTitle } from "../../lib/sanitize";
 import { fetchGraphQL } from "../../lib/api";
 import GET_POSTS_BY_TAG from "../../lib/queries/getPostsByTag";

--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeTitle } from "../../lib/sanitize";
 import { fetchGraphQL } from "../../lib/api";
 import GET_POSTS_BY_TAG from "../../lib/queries/getPostsByTag";
 import type { Post, Size } from "../../types";
@@ -31,6 +32,7 @@ if (tag) {
   }
 }
 ---
+import { sanitizeTitle } from "../../lib/sanitize";
 
 {
   tag && locationPosts.length > 0 && (
@@ -41,7 +43,7 @@ if (tag) {
           <li class="heading">
             <h4>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={post?.title} />
+                <Fragment set:html={sanitizeTitle(post?.title)} />
               </a>
             </h4>
             <a href={`/${post?.slug}`} rel="noopener noreferrer">

--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -32,7 +32,6 @@ if (tag) {
   }
 }
 ---
-import { sanitizeTitle } from "../../lib/sanitize";
 
 {
   tag && locationPosts.length > 0 && (

--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -1,7 +1,7 @@
 ---
-import { sanitizeTitle } from "../../lib/sanitize";
 import { fetchGraphQL } from "../../lib/api";
 import GET_POSTS_BY_TAG from "../../lib/queries/getPostsByTag";
+import { sanitizeTitle } from "../../lib/sanitize";
 import type { Post, Size } from "../../types";
 
 const { tag } = Astro.props;

--- a/src/layouts/BestRoastLayout.astro
+++ b/src/layouts/BestRoastLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/post.css";
+import { sanitizeContent } from "../lib/sanitize";
 import Comments from "../components/comments/comments.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
 import Newsletter from "../components/newsletter/newsletter.astro";
@@ -26,7 +27,7 @@ const {
   <FeaturedPostHeader imageSrc={opengraphImage} title={pageTitle} />
 
   <div class="container">
-    <div set:html={content} />
+    <div set:html={sanitizeContent(content)} />
 
     {
       topRated.map((post: Post) => (

--- a/src/layouts/BestRoastLayout.astro
+++ b/src/layouts/BestRoastLayout.astro
@@ -1,9 +1,9 @@
 ---
 import "../styles/post.css";
-import { sanitizeContent } from "../lib/sanitize";
 import Comments from "../components/comments/comments.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
 import Newsletter from "../components/newsletter/newsletter.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import type { Post } from "../types";
 import BaseLayout from "./BaseLayout.astro";
 

--- a/src/layouts/TubeLinePageLayout.astro
+++ b/src/layouts/TubeLinePageLayout.astro
@@ -7,6 +7,7 @@ import type { Page, Post, Comments as ThreadedComments } from "../types";
 import BaseLayout from "./BaseLayout.astro";
 
 import "../styles/post.css";
+import { sanitizeContent } from "../lib/sanitize";
 
 type Props = {
   singlePage: Page;
@@ -38,7 +39,7 @@ const {
   />
 
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <section>
       <h3 class={`heading-underline ${headingClass}`}>
         Roast Dinners On The {lineName} Line

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,18 @@
+import sanitizeHtml from "sanitize-html";
+
+const contentOptions: sanitizeHtml.IOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "figure", "figcaption", "iframe"]),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    img: ["src", "srcset", "alt", "width", "height", "loading", "class"],
+    iframe: ["src", "width", "height", "allowfullscreen", "frameborder", "title"],
+    "*": ["class", "id"],
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+};
+
+export const sanitizeContent = (html: string | null | undefined): string =>
+  sanitizeHtml(html ?? "", contentOptions);
+
+export const sanitizeTitle = (html: string | null | undefined): string =>
+  sanitizeHtml(html ?? "", { allowedTags: [], allowedAttributes: {} });

--- a/src/pages/annual-roastatistics.astro
+++ b/src/pages/annual-roastatistics.astro
@@ -1,5 +1,4 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import Comments from "../components/comments/comments.astro";
 import Dropdown from "../components/dropdown/dropdown.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
@@ -8,6 +7,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import { fetchGraphQL } from "../lib/api";
 import { getSinglePageData } from "../lib/getSinglePageData";
 import GET_ALL_POSTS from "../lib/queries/getAllPosts";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import { fetchAllPosts } from "../lib/yearlyRoastStats";
 import type { Post } from "../types";

--- a/src/pages/annual-roastatistics.astro
+++ b/src/pages/annual-roastatistics.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import Comments from "../components/comments/comments.astro";
 import Dropdown from "../components/dropdown/dropdown.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
@@ -147,6 +148,7 @@ const topMeats = Array.from(meatCounts.entries())
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -158,7 +160,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    {singlePage.content ? <div set:html={singlePage.content} /> : null}
+    {singlePage.content ? <div set:html={sanitizeContent(singlePage.content)} /> : null}
     <p>
       Select a year to see your roast dinner averages and where in London you
       reviewed roasts.

--- a/src/pages/annual-roastatistics.astro
+++ b/src/pages/annual-roastatistics.astro
@@ -148,7 +148,6 @@ const topMeats = Array.from(meatCounts.entries())
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/annual-roastatistics.astro
+++ b/src/pages/annual-roastatistics.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import Comments from "../components/comments/comments.astro";
 import Dropdown from "../components/dropdown/dropdown.astro";

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,8 +1,8 @@
 ---
-import { sanitizeTitle } from "../lib/sanitize";
 import Dropdown from "../components/dropdown/dropdown.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { fetchPostsByDate } from "../lib/graphql";
+import { sanitizeTitle } from "../lib/sanitize";
 import "../styles/index.css";
 import type { Post } from "../types";
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -39,7 +39,6 @@ try {
   console.error("Error fetching posts:", error);
 }
 ---
-import { sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle="Archive"

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeTitle } from "../lib/sanitize";
 import Dropdown from "../components/dropdown/dropdown.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { fetchPostsByDate } from "../lib/graphql";
@@ -38,6 +39,7 @@ try {
   console.error("Error fetching posts:", error);
 }
 ---
+import { sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle="Archive"
@@ -74,7 +76,7 @@ try {
             <li class="heading">
               <h2>
                 <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                  <Fragment set:html={post?.title} />
+                  <Fragment set:html={sanitizeTitle(post?.title)} />
                 </a>
               </h2>
               <a

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeTitle } from "../lib/sanitize";
 import Dropdown from "../components/dropdown/dropdown.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";

--- a/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
+++ b/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
+++ b/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
+++ b/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
@@ -56,7 +56,6 @@ const avgNonIndependent = (nonIndependentTotal / nonIndependentCount).toFixed(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
+++ b/src/pages/are-independent-restaurants-better-than-chains-at-roast-dinners.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -55,6 +56,7 @@ const avgNonIndependent = (nonIndependentTotal / nonIndependentCount).toFixed(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -66,7 +68,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <p>Number of independent restaurants: {independentCount}</p>
     <p>Number of non-independent restaurants: {nonIndependentCount}</p>
     <p>Average score for independent restaurants: {avgIndependent}</p>

--- a/src/pages/are-roast-dinners-better-in-winter.astro
+++ b/src/pages/are-roast-dinners-better-in-winter.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/are-roast-dinners-better-in-winter.astro
+++ b/src/pages/are-roast-dinners-better-in-winter.astro
@@ -68,7 +68,6 @@ const totalReviews = Object.values(seasonStats).reduce(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/are-roast-dinners-better-in-winter.astro
+++ b/src/pages/are-roast-dinners-better-in-winter.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/are-roast-dinners-better-in-winter.astro
+++ b/src/pages/are-roast-dinners-better-in-winter.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -67,6 +68,7 @@ const totalReviews = Object.values(seasonStats).reduce(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -78,7 +80,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         Object.entries(seasonStats).map(([season, { totalRatings, count }]) => {

--- a/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
+++ b/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
+++ b/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
@@ -58,7 +58,6 @@ const yearsSorted = Object.entries(yearStats)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
+++ b/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import { organiseComments } from "../lib/utils";

--- a/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
+++ b/src/pages/are-roast-dinners-in-london-getting-better-or-worse.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -57,6 +58,7 @@ const yearsSorted = Object.entries(yearStats)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -68,7 +70,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         yearsSorted.map(({ year, average, count }) => (

--- a/src/pages/best-carrots-in-london.astro
+++ b/src/pages/best-carrots-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-carrots-in-london.astro
+++ b/src/pages/best-carrots-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-carrots-in-london.astro
+++ b/src/pages/best-carrots-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-carrots-in-london.astro
+++ b/src/pages/best-carrots-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-cauliflower-cheese-in-london.astro
+++ b/src/pages/best-cauliflower-cheese-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-cauliflower-cheese-in-london.astro
+++ b/src/pages/best-cauliflower-cheese-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-cauliflower-cheese-in-london.astro
+++ b/src/pages/best-cauliflower-cheese-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-cauliflower-cheese-in-london.astro
+++ b/src/pages/best-cauliflower-cheese-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-crackling-in-london.astro
+++ b/src/pages/best-crackling-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-crackling-in-london.astro
+++ b/src/pages/best-crackling-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-crackling-in-london.astro
+++ b/src/pages/best-crackling-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-crackling-in-london.astro
+++ b/src/pages/best-crackling-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-gravy-in-london.astro
+++ b/src/pages/best-gravy-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-gravy-in-london.astro
+++ b/src/pages/best-gravy-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-gravy-in-london.astro
+++ b/src/pages/best-gravy-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-gravy-in-london.astro
+++ b/src/pages/best-gravy-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-pork-belly-in-london.astro
+++ b/src/pages/best-pork-belly-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-pork-belly-in-london.astro
+++ b/src/pages/best-pork-belly-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-pork-belly-in-london.astro
+++ b/src/pages/best-pork-belly-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-pork-belly-in-london.astro
+++ b/src/pages/best-pork-belly-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-beef-in-london.astro
+++ b/src/pages/best-roast-beef-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-roast-beef-in-london.astro
+++ b/src/pages/best-roast-beef-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-roast-beef-in-london.astro
+++ b/src/pages/best-roast-beef-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-roast-beef-in-london.astro
+++ b/src/pages/best-roast-beef-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-chicken-in-london.astro
+++ b/src/pages/best-roast-chicken-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;

--- a/src/pages/best-roast-chicken-in-london.astro
+++ b/src/pages/best-roast-chicken-in-london.astro
@@ -23,7 +23,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-roast-chicken-in-london.astro
+++ b/src/pages/best-roast-chicken-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 export const prerender = true;
 
 import "../styles/post.css";

--- a/src/pages/best-roast-chicken-in-london.astro
+++ b/src/pages/best-roast-chicken-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 export const prerender = true;
 
@@ -22,6 +23,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -33,7 +35,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-lamb-in-london.astro
+++ b/src/pages/best-roast-lamb-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/best-roast-lamb-in-london.astro
+++ b/src/pages/best-roast-lamb-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/best-roast-lamb-in-london.astro
+++ b/src/pages/best-roast-lamb-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -23,6 +24,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -34,7 +36,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-lamb-in-london.astro
+++ b/src/pages/best-roast-lamb-in-london.astro
@@ -24,7 +24,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-roast-lists.astro
+++ b/src/pages/best-roast-lists.astro
@@ -66,7 +66,6 @@ try {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-roast-lists.astro
+++ b/src/pages/best-roast-lists.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Page, Size } from "../types";
 import "../styles/post.css";

--- a/src/pages/best-roast-lists.astro
+++ b/src/pages/best-roast-lists.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Page, Size } from "../types";
@@ -65,6 +66,7 @@ try {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -88,7 +90,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
               <li class="heading">
                 <h3>
                   <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                    <Fragment set:html={post?.title} />
+                    <Fragment set:html={sanitizeTitle(post?.title)} />
                   </a>
                 </h3>
                 <a
@@ -120,7 +122,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
               <li class="heading">
                 <h3>
                   <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                    <Fragment set:html={post?.title} />
+                    <Fragment set:html={sanitizeTitle(post?.title)} />
                   </a>
                 </h3>
                 <a

--- a/src/pages/best-roast-lists.astro
+++ b/src/pages/best-roast-lists.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/best-roast-pork-in-london.astro
+++ b/src/pages/best-roast-pork-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/best-roast-pork-in-london.astro
+++ b/src/pages/best-roast-pork-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/best-roast-pork-in-london.astro
+++ b/src/pages/best-roast-pork-in-london.astro
@@ -25,7 +25,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-roast-pork-in-london.astro
+++ b/src/pages/best-roast-pork-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -24,6 +25,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -35,7 +37,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-potatoes-in-london.astro
+++ b/src/pages/best-roast-potatoes-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/best-roast-potatoes-in-london.astro
+++ b/src/pages/best-roast-potatoes-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/best-roast-potatoes-in-london.astro
+++ b/src/pages/best-roast-potatoes-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -23,6 +24,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -34,7 +36,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-roast-potatoes-in-london.astro
+++ b/src/pages/best-roast-potatoes-in-london.astro
@@ -24,7 +24,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/best-yorkshire-puddings-in-london.astro
+++ b/src/pages/best-yorkshire-puddings-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/best-yorkshire-puddings-in-london.astro
+++ b/src/pages/best-yorkshire-puddings-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/best-yorkshire-puddings-in-london.astro
+++ b/src/pages/best-yorkshire-puddings-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -23,6 +24,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -34,7 +36,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/best-yorkshire-puddings-in-london.astro
+++ b/src/pages/best-yorkshire-puddings-in-london.astro
@@ -24,7 +24,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -1,8 +1,8 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { sanitizeTitle } from "../../lib/sanitize";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
+import { sanitizeTitle } from "../../lib/sanitize";
 import "../../styles/index.css";
 import type { Post } from "../../types";
 

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { sanitizeTitle } from "../../lib/sanitize";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
 import "../../styles/index.css";
@@ -119,7 +120,7 @@ const averageRating =
             >
               <h3>
                 <a href={`/${post.slug}`} rel="noopener noreferrer">
-                  <Fragment set:html={post.title} />
+                  <Fragment set:html={sanitizeTitle(post.title)} />
                 </a>
               </h3>
               <a

--- a/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
+++ b/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -70,6 +71,7 @@ const maxAverage = sortedByAverage[0]?.average ?? 10;
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -81,7 +83,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <ul class={styles.dayChart} aria-label="Average roast dinner ratings by day of review publication">
       {

--- a/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
+++ b/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
+++ b/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";

--- a/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
+++ b/src/pages/does-the-day-a-review-is-published-affect-the-rating.astro
@@ -71,7 +71,6 @@ const maxAverage = sortedByAverage[0]?.average ?? 10;
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
+++ b/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
+++ b/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
+++ b/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
@@ -59,7 +59,6 @@ const areaOrder = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
+++ b/src/pages/geographical-spread-of-roast-dinner-reviews-each-year.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -58,6 +59,7 @@ const areaOrder = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -69,7 +71,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         orderedYears

--- a/src/pages/how-many-great-roast-dinners-each-year.astro
+++ b/src/pages/how-many-great-roast-dinners-each-year.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/how-many-great-roast-dinners-each-year.astro
+++ b/src/pages/how-many-great-roast-dinners-each-year.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";

--- a/src/pages/how-many-great-roast-dinners-each-year.astro
+++ b/src/pages/how-many-great-roast-dinners-each-year.astro
@@ -25,7 +25,6 @@ const greatRoastsByYear = buildYearlyRoastStats(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/how-many-great-roast-dinners-each-year.astro
+++ b/src/pages/how-many-great-roast-dinners-each-year.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -24,6 +25,7 @@ const greatRoastsByYear = buildYearlyRoastStats(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -35,7 +37,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <ul>
       {

--- a/src/pages/how-many-shit-roast-dinners-each-year.astro
+++ b/src/pages/how-many-shit-roast-dinners-each-year.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/how-many-shit-roast-dinners-each-year.astro
+++ b/src/pages/how-many-shit-roast-dinners-each-year.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";

--- a/src/pages/how-many-shit-roast-dinners-each-year.astro
+++ b/src/pages/how-many-shit-roast-dinners-each-year.astro
@@ -25,7 +25,6 @@ const greatRoastsByYear = buildYearlyRoastStats(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/how-many-shit-roast-dinners-each-year.astro
+++ b/src/pages/how-many-shit-roast-dinners-each-year.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -24,6 +25,7 @@ const greatRoastsByYear = buildYearlyRoastStats(
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -35,7 +37,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <ul>
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/index.css";
 import { MyRoastListItem } from "../components/my-roast-list-item/MyRoastListItem";
@@ -260,6 +261,7 @@ try {
   console.error("Error fetching features data:", error);
 }
 ---
+import { sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle="Home of Roast Dinners In London"
@@ -274,7 +276,7 @@ try {
           <li class="heading" data-post-date={post?.date}>
             <h3>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={post?.title} />
+                <Fragment set:html={sanitizeTitle(post?.title)} />
               </a>
             </h3>
             <a
@@ -303,7 +305,7 @@ try {
           <li class="heading">
             <h3>
               <a href={page?.slug} rel="noopener noreferrer">
-                <Fragment set:html={page?.title} />
+                <Fragment set:html={sanitizeTitle(page?.title)} />
               </a>
             </h3>
             <a href={page?.slug} rel="noopener noreferrer">
@@ -347,7 +349,7 @@ try {
           <li class="heading">
             <h3>
               <a href={page?.slug} rel="noopener noreferrer">
-                <Fragment set:html={page?.title} />
+                <Fragment set:html={sanitizeTitle(page?.title)} />
               </a>
             </h3>
             <a href={page?.slug} rel="noopener noreferrer">
@@ -406,7 +408,7 @@ try {
           <li class="heading">
             <h3>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={post?.title} />
+                <Fragment set:html={sanitizeTitle(post?.title)} />
               </a>
             </h3>
             <a
@@ -437,7 +439,7 @@ try {
           <li class="heading">
             <h3>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={post?.title} />
+                <Fragment set:html={sanitizeTitle(post?.title)} />
               </a>
             </h3>
             <a
@@ -466,7 +468,7 @@ try {
           <li class="heading">
             <h3>
               <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={post?.title} />
+                <Fragment set:html={sanitizeTitle(post?.title)} />
               </a>
             </h3>
             <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeTitle } from "../lib/sanitize";
 import "../styles/index.css";
 import { MyRoastListItem } from "../components/my-roast-list-item/MyRoastListItem";
 import Newsletter from "../components/newsletter/newsletter.astro";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -261,7 +261,6 @@ try {
   console.error("Error fetching features data:", error);
 }
 ---
-import { sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle="Home of Roast Dinners In London"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/index.css";

--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -70,7 +70,6 @@ const roastListStructuredData = {
   })),
 };
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -69,6 +70,7 @@ const roastListStructuredData = {
   })),
 };
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -81,7 +83,7 @@ const roastListStructuredData = {
     title={singlePage.title}
   />
   <div class="container league-container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <div class="sort-posts-loading" id="sort-posts-loading">
       <div class="loading-content">

--- a/src/pages/league-of-roasts.astro
+++ b/src/pages/league-of-roasts.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/roast-dinner-inflation.astro
+++ b/src/pages/roast-dinner-inflation.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/roast-dinner-inflation.astro
+++ b/src/pages/roast-dinner-inflation.astro
@@ -75,7 +75,6 @@ const averagePrices = [...yearStats.entries()].map(([year, prices]) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/roast-dinner-inflation.astro
+++ b/src/pages/roast-dinner-inflation.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -74,6 +75,7 @@ const averagePrices = [...yearStats.entries()].map(([year, prices]) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -85,7 +87,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <ul>
       {

--- a/src/pages/roast-dinner-inflation.astro
+++ b/src/pages/roast-dinner-inflation.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
+++ b/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
+++ b/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
+++ b/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
@@ -27,7 +27,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
+++ b/src/pages/roast-dinners-at-the-top-50-gastropubs-2025.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -26,6 +27,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -37,7 +39,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/roast-dinners-in-london-with-mashed-potato.astro
+++ b/src/pages/roast-dinners-in-london-with-mashed-potato.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/roast-dinners-in-london-with-mashed-potato.astro
+++ b/src/pages/roast-dinners-in-london-with-mashed-potato.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/roast-dinners-in-london-with-mashed-potato.astro
+++ b/src/pages/roast-dinners-in-london-with-mashed-potato.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -55,6 +56,7 @@ const topRoastPosts = allRoastPosts.slice(0, 5);
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -66,7 +68,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <ul>
       {

--- a/src/pages/roast-dinners-in-london-with-mashed-potato.astro
+++ b/src/pages/roast-dinners-in-london-with-mashed-potato.astro
@@ -56,7 +56,6 @@ const topRoastPosts = allRoastPosts.slice(0, 5);
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/roastatistics.astro
+++ b/src/pages/roastatistics.astro
@@ -75,7 +75,6 @@ if (!singlePage) {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/roastatistics.astro
+++ b/src/pages/roastatistics.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Page, Size } from "../types";
@@ -74,6 +75,7 @@ if (!singlePage) {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -93,7 +95,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
             <li class="heading">
               <h3>
                 <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                  <Fragment set:html={post?.title} />
+                  <Fragment set:html={sanitizeTitle(post?.title)} />
                 </a>
               </h3>
               <a

--- a/src/pages/roastatistics.astro
+++ b/src/pages/roastatistics.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Page, Size } from "../types";
 import "../styles/post.css";

--- a/src/pages/roastatistics.astro
+++ b/src/pages/roastatistics.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent, sanitizeTitle } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/to-do-list.astro
+++ b/src/pages/to-do-list.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/to-do-list.astro
+++ b/src/pages/to-do-list.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";

--- a/src/pages/to-do-list.astro
+++ b/src/pages/to-do-list.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -15,6 +16,7 @@ const singlePage = await getSinglePageData({ variables });
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -26,7 +28,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <Newsletter />
 
     <Comments threadedComments={threadedComments} postId={singlePage.pageId} />

--- a/src/pages/to-do-list.astro
+++ b/src/pages/to-do-list.astro
@@ -16,7 +16,6 @@ const singlePage = await getSinglePageData({ variables });
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/tube-stations-with-roast-dinner-reviews.astro
+++ b/src/pages/tube-stations-with-roast-dinner-reviews.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/tube-stations-with-roast-dinner-reviews.astro
+++ b/src/pages/tube-stations-with-roast-dinner-reviews.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -598,6 +599,7 @@ const overgroundStations = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -609,7 +611,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <div class="entry-content container">
       <p>

--- a/src/pages/tube-stations-with-roast-dinner-reviews.astro
+++ b/src/pages/tube-stations-with-roast-dinner-reviews.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/tube-stations-with-roast-dinner-reviews.astro
+++ b/src/pages/tube-stations-with-roast-dinner-reviews.astro
@@ -599,7 +599,6 @@ const overgroundStations = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
+++ b/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import BestPostsList from "../components/best-posts-list/best-posts-list.astro";

--- a/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
+++ b/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";

--- a/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
+++ b/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
@@ -25,7 +25,6 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
+++ b/src/pages/where-to-get-an-indian-roast-dinner-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { getTopRoastDinnerPosts, organiseComments } from "../lib/utils";
 import "../styles/post.css";
@@ -24,6 +25,7 @@ const filtered = getTopRoastDinnerPosts(allPosts, {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -35,7 +37,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     <BestPostsList posts={filtered} />
 

--- a/src/pages/which-area-of-london-do-i-visit-most-often.astro
+++ b/src/pages/which-area-of-london-do-i-visit-most-often.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-area-of-london-do-i-visit-most-often.astro
+++ b/src/pages/which-area-of-london-do-i-visit-most-often.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -61,6 +62,7 @@ const preferredOrder = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -72,7 +74,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     {
       Array.from(areaCountsByYear.entries())

--- a/src/pages/which-area-of-london-do-i-visit-most-often.astro
+++ b/src/pages/which-area-of-london-do-i-visit-most-often.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-area-of-london-do-i-visit-most-often.astro
+++ b/src/pages/which-area-of-london-do-i-visit-most-often.astro
@@ -62,7 +62,6 @@ const preferredOrder = [
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
@@ -62,7 +62,6 @@ const areaStats = Object.entries(areaRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-best-roast-dinners.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -61,6 +62,7 @@ const areaStats = Object.entries(areaRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -72,7 +74,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         areaStats.map((area) => (

--- a/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
@@ -64,7 +64,6 @@ const areaStats = Object.entries(areaPrices)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-area-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -63,6 +64,7 @@ const areaStats = Object.entries(areaPrices)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -74,7 +76,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         areaStats.map((area) => (

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -61,6 +62,7 @@ const districtStats = Object.entries(districtRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -72,7 +74,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         districtStats.map((district) => (

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -62,7 +62,6 @@ const districtStats = Object.entries(districtRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
@@ -61,7 +61,6 @@ const boroughStats = Object.entries(boroughPrices)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
+++ b/src/pages/which-borough-of-london-has-the-cheapest-roast-dinners.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -60,6 +61,7 @@ const boroughStats = Object.entries(boroughPrices)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -71,7 +73,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         boroughStats.map((b) => (

--- a/src/pages/which-fare-zones-do-i-visit-most-often.astro
+++ b/src/pages/which-fare-zones-do-i-visit-most-often.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-fare-zones-do-i-visit-most-often.astro
+++ b/src/pages/which-fare-zones-do-i-visit-most-often.astro
@@ -66,7 +66,6 @@ const sortZones = (a: [string, number], b: [string, number]) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-fare-zones-do-i-visit-most-often.astro
+++ b/src/pages/which-fare-zones-do-i-visit-most-often.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-fare-zones-do-i-visit-most-often.astro
+++ b/src/pages/which-fare-zones-do-i-visit-most-often.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -65,6 +66,7 @@ const sortZones = (a: [string, number], b: [string, number]) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -76,7 +78,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
 
     {
       Array.from(zoneCountsByYear.entries())

--- a/src/pages/which-is-lord-gravy-favourite-meat.astro
+++ b/src/pages/which-is-lord-gravy-favourite-meat.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-is-lord-gravy-favourite-meat.astro
+++ b/src/pages/which-is-lord-gravy-favourite-meat.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-is-lord-gravy-favourite-meat.astro
+++ b/src/pages/which-is-lord-gravy-favourite-meat.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -55,6 +56,7 @@ const meatStats = Object.entries(meatRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -66,7 +68,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         meatStats.map((meat) => (

--- a/src/pages/which-is-lord-gravy-favourite-meat.astro
+++ b/src/pages/which-is-lord-gravy-favourite-meat.astro
@@ -56,7 +56,6 @@ const meatStats = Object.entries(meatRatings)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
+++ b/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
+++ b/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -62,6 +63,7 @@ const chainStats = Object.entries(ownerScores)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -73,7 +75,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul>
       {
         chainStats.map((chain) => (

--- a/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
+++ b/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
+++ b/src/pages/which-is-the-best-chain-for-a-roast-dinner.astro
@@ -63,7 +63,6 @@ const chainStats = Object.entries(ownerScores)
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-month-are-roast-dinners-better.astro
+++ b/src/pages/which-month-are-roast-dinners-better.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";

--- a/src/pages/which-month-are-roast-dinners-better.astro
+++ b/src/pages/which-month-are-roast-dinners-better.astro
@@ -1,6 +1,6 @@
 ---
-import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";

--- a/src/pages/which-month-are-roast-dinners-better.astro
+++ b/src/pages/which-month-are-roast-dinners-better.astro
@@ -91,7 +91,6 @@ const monthlyAverages = monthOrder.map((month) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
-import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}

--- a/src/pages/which-month-are-roast-dinners-better.astro
+++ b/src/pages/which-month-are-roast-dinners-better.astro
@@ -1,4 +1,5 @@
----
+﻿---
+import { sanitizeContent } from "../lib/sanitize";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -90,6 +91,7 @@ const monthlyAverages = monthOrder.map((month) => {
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
+import { sanitizeContent } from "../lib/sanitize";
 
 <BaseLayout
   pageTitle={singlePage.title}
@@ -101,7 +103,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={singlePage.content} />
+    <div set:html={sanitizeContent(singlePage.content)} />
     <ul class="month-chart">
       {
         monthlyAverages.map(({ month, average, count }) => (


### PR DESCRIPTION
Fixes XSS vulnerability (issue #440) — WordPress content and post titles were rendered unsanitized across 40+ pages. Extracts a shared sanitize helper (sanitizeContent / sanitizeTitle) and applies it everywhere set:html is used with API data.