### PR TITLE
chore(typescript): improve type safety across API handlers and components

### DIFF
--- a/src/components/sunday-roast-planner/sunday-roast-planner.tsx
+++ b/src/components/sunday-roast-planner/sunday-roast-planner.tsx
@@ -60,21 +60,21 @@ const SundayRoastPlanner = ({
 
   const uniqueAreas = useMemo(
     () =>
-      Array.from(new Set(openPosts.map((p) => p.areas?.nodes[0]?.name).filter(Boolean)))
+      Array.from(new Set(openPosts.map((p) => p.areas?.nodes[0]?.name).filter((a): a is string => Boolean(a))))
         .filter((a) => a !== "Not Really London")
-        .sort() as string[],
+        .sort(),
     [openPosts]
   );
 
   const uniqueBoroughs = useMemo(
     () =>
-      Array.from(new Set(openPosts.map((p) => p.boroughs?.nodes[0]?.name).filter(Boolean))).sort() as string[],
+      Array.from(new Set(openPosts.map((p) => p.boroughs?.nodes[0]?.name).filter((a): a is string => Boolean(a)))).sort(),
     [openPosts]
   );
 
   const uniqueTubeLines = useMemo(
     () =>
-      Array.from(new Set(openPosts.map((p) => p.tubeLines?.nodes[0]?.name).filter(Boolean))).sort() as string[],
+      Array.from(new Set(openPosts.map((p) => p.tubeLines?.nodes[0]?.name).filter((a): a is string => Boolean(a)))).sort(),
     [openPosts]
   );
 

--- a/src/pages/api/profile.ts
+++ b/src/pages/api/profile.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../../lib/db";
 import { users } from "../../lib/schema";
 
-export async function GET(context: APIContext) {
+export async function GET(context: APIContext): Promise<Response> {
   const auth = context.locals.auth();
   const { userId: clerkId } = auth;
 

--- a/src/pages/api/wishlist.ts
+++ b/src/pages/api/wishlist.ts
@@ -3,12 +3,18 @@ import { and, eq } from "drizzle-orm";
 import { db } from "../../lib/db";
 import { users, wishlistItems } from "../../lib/schema";
 
+type WishlistPayload = {
+  postSlug: string;
+  postTitle: string;
+  postRating?: string | null;
+};
+
 async function getUserId(clerkId: string): Promise<string | null> {
   const [user] = await db.select({ id: users.id }).from(users).where(eq(users.clerkId, clerkId)).limit(1);
   return user?.id ?? null;
 }
 
-export async function GET(context: APIContext) {
+export async function GET(context: APIContext): Promise<Response> {
   const { userId: clerkId } = context.locals.auth();
 
   if (!clerkId) {
@@ -31,19 +37,15 @@ export async function GET(context: APIContext) {
   });
 }
 
-export async function POST(context: APIContext) {
+export async function POST(context: APIContext): Promise<Response> {
   const { userId: clerkId } = context.locals.auth();
 
   if (!clerkId) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
   }
 
-  const body = await context.request.json();
-  const { postSlug, postTitle, postRating } = body as {
-    postSlug: string;
-    postTitle: string;
-    postRating?: string | null;
-  };
+  const body = await context.request.json() as WishlistPayload;
+  const { postSlug, postTitle, postRating } = body;
 
   if (!postSlug || !postTitle) {
     return new Response(JSON.stringify({ error: "postSlug and postTitle are required" }), { status: 400 });

--- a/src/pages/api/wishlist/[slug].ts
+++ b/src/pages/api/wishlist/[slug].ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "../../../lib/db";
 import { users, wishlistItems } from "../../../lib/schema";
 
-export async function DELETE(context: APIContext) {
+export async function DELETE(context: APIContext): Promise<Response> {
   const { userId: clerkId } = context.locals.auth();
 
   if (!clerkId) {

--- a/src/pages/guessthescore/api/personal-best.ts
+++ b/src/pages/guessthescore/api/personal-best.ts
@@ -8,7 +8,7 @@ async function getUserId(clerkId: string): Promise<string | null> {
   return user?.id ?? null;
 }
 
-export async function GET(context: APIContext) {
+export async function GET(context: APIContext): Promise<Response> {
   const { userId: clerkId } = context.locals.auth();
 
   if (!clerkId) {
@@ -33,15 +33,15 @@ export async function GET(context: APIContext) {
   });
 }
 
-export async function POST(context: APIContext) {
+export async function POST(context: APIContext): Promise<Response> {
   const { userId: clerkId } = context.locals.auth();
 
   if (!clerkId) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
   }
 
-  const body = await context.request.json();
-  const { score } = body as { score: unknown };
+  const body = await context.request.json() as { score: unknown };
+  const { score } = body;
 
   if (typeof score !== "number" || !Number.isInteger(score) || score < 0 || score > 100) {
     return new Response(JSON.stringify({ error: "Invalid score" }), { status: 400 });

--- a/src/pages/guessthescore/api/scores.ts
+++ b/src/pages/guessthescore/api/scores.ts
@@ -5,7 +5,7 @@ export const GET: APIRoute = async () => {
   try {
     const results = await kv.zrange("leaderboard", 0, 9, { rev: true });
 
-    const scores = (results as unknown[]).flatMap((member) => {
+    const scores = (results as Array<string | Record<string, unknown>>).flatMap((member) => {
       if (typeof member === "object" && member !== null) return [member];
       if (typeof member === "string") {
         try {


### PR DESCRIPTION
## Summary

Monday TypeScript pass — tightens type safety in six files without changing runtime behaviour. All 366 tests pass.

### Changes

- **`sunday-roast-planner.tsx`** — replace three `as string[]` casts on `useMemo` derived arrays with a type-predicate filter `(a): a is string => Boolean(a)`. TypeScript now narrows the type at the `filter` call site instead of at a downstream unsafe assertion.

- **`scores.ts`** — replace `as unknown[]` on the `kv.zrange` result with `as Array<string | Record<string, unknown>>`. This accurately describes both shapes the leaderboard data can take (raw JSON string or already-parsed object) while still allowing the `flatMap` narrowing to work.

- **`wishlist.ts`** — extract the inline `body as { postSlug, postTitle, postRating }` type assertion to a named `type WishlistPayload` alias and move the assertion to the `request.json()` call site. Adds explicit `Promise<Response>` return types to both `GET` and `POST`.

- **`wishlist/[slug].ts`** — adds explicit `Promise<Response>` return type to `DELETE`.

- **`profile.ts`** — adds explicit `Promise<Response>` return type to `GET`.

- **`personal-best.ts`** — adds explicit `Promise<Response>` return types to both `GET` and `POST`; moves the `as { score: unknown }` assertion to the `request.json()` call site for consistency.

### What was not changed

- `interface Window` in `global.d.ts` and `env.d.ts` — declaration merging requires `interface`, not `type`; these are correct as-is.
- `as unknown as APIContext` patterns in test files — this is the standard Astro testing idiom when only a subset of context is needed; replacing it would require test infrastructure changes beyond this scope.
- `submit-score.ts` body type `{ name?: unknown; score?: unknown; token?: unknown }` — intentionally loose to allow the runtime guards below to narrow each field; correct as written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdUWEcPaXTpK84QBjoLVbh)_