### PR TITLE
Use type-safe generic instead of unsafe cast in fetchAllSlugs

### DIFF
--- a/src/lib/fetchAllSlugs.ts
+++ b/src/lib/fetchAllSlugs.ts
@@ -17,7 +17,7 @@ export async function fetchAllSlugs(entity: GraphEntity, query: string): Promise
   let endCursor: string | null = null;
 
   while (hasNextPage) {
-    const data = await fetchGraphQL<SlugsResponse>(query, {
+    const data: SlugsResponse = await fetchGraphQL<SlugsResponse>(query, {
       first: 100,
       after: endCursor,
     });

--- a/src/lib/fetchAllSlugs.ts
+++ b/src/lib/fetchAllSlugs.ts
@@ -17,10 +17,10 @@ export async function fetchAllSlugs(entity: GraphEntity, query: string): Promise
   let endCursor: string | null = null;
 
   while (hasNextPage) {
-    const data = (await fetchGraphQL(query, {
+    const data = await fetchGraphQL<SlugsResponse>(query, {
       first: 100,
       after: endCursor,
-    })) as SlugsResponse;
+    });
 
     const items = data[entity].nodes;
 


### PR DESCRIPTION
## Summary
- Replace `(await fetchGraphQL(...)) as SlugsResponse` with `fetchGraphQL<SlugsResponse>(...)` in `src/lib/fetchAllSlugs.ts`
- The `as` cast bypasses TypeScript's type system entirely; using the generic parameter lets TypeScript verify the return type flows correctly through the function
- This is consistent with how `getAllRoastDinnerPosts.ts` already calls `fetchGraphQL` — both files now follow the same pattern

## Category
Strict typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdAp6r7huUPgGwLYtocarf)_