### PR TITLE
Remove dead commented-out imports

### DIFF
--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -2,8 +2,6 @@ import L from "leaflet";
 import { useEffect, useMemo, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
 
-// import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
-
 type Marker = {
   lat: number;
   lng: number;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,8 +5,6 @@ import "./layout.css";
 import { SEO } from "astro-seo";
 import logo1 from "../images/logo-1.png";
 
-// import logo3 from "/images/logo-3.png";
-
 const {
   pageTitle,
   description,


### PR DESCRIPTION
## Summary
- Removed a commented-out import in `src/components/roast-map/roast-map.tsx` that referenced `leaflet-defaulticon-compatibility`, a package that isn't even listed in `package.json`
- Removed a commented-out `logo3` image import in `src/layouts/BaseLayout.astro` that was never used

## Category
Dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QWTqrcwsbAfRcxnfuuH4JE)_