### PR TITLE
fix(a11y): accessibility and SEO improvements (2026-07-02)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,9 @@
 
 User-agent: *
 Disallow: /404.html
+Disallow: /flags
+Disallow: /sign-in
+Disallow: /api/
 
 # Allow all other pages
 Allow: /

--- a/src/components/add-comment/add-comment.astro
+++ b/src/components/add-comment/add-comment.astro
@@ -16,11 +16,11 @@ const messageColor = "black";
 >
   <div>
     <label for={`authorName-${parentId}`}>Name:</label>
-    <input type="text" name="authorName" id={`authorName-${parentId}`} required />
+    <input type="text" name="authorName" id={`authorName-${parentId}`} autocomplete="name" required />
   </div>
   <div>
     <label for={`email-${parentId}`}>Email:</label>
-    <input type="email" name="email" id={`email-${parentId}`} required />
+    <input type="email" name="email" id={`email-${parentId}`} autocomplete="email" required />
   </div>
   <div>
     <label for={`commentText-${parentId}`}>Comment:</label>

--- a/src/components/best-posts-list/best-posts-list.astro
+++ b/src/components/best-posts-list/best-posts-list.astro
@@ -46,6 +46,9 @@ const { posts } = Astro.props as Props;
           <img
             src={post.featuredImage.node.sourceUrl}
             alt={post.featuredImage.node.altText || `Image for ${post.title}`}
+            width="400"
+            height="300"
+            loading="lazy"
           />
         </div>
       )}

--- a/src/components/comments/comments.astro
+++ b/src/components/comments/comments.astro
@@ -29,11 +29,11 @@ const { threadedComments, postId } = Astro.props as Props;
   <form id="comment-form" class="comment-form" data-post-id={postId} data-graphql-url={import.meta.env.PUBLIC_GRAPHQL_URL}>
     <div>
       <label for="authorName">Name:</label>
-      <input type="text" id="authorName" name="authorName" required />
+      <input type="text" id="authorName" name="authorName" autocomplete="name" required />
     </div>
     <div>
       <label for="email">Email:</label>
-      <input type="email" id="email" name="email" required />
+      <input type="email" id="email" name="email" autocomplete="email" required />
     </div><div>
       <label for="commentText">Comment:</label>
       <textarea id="commentText" name="commentText" required></textarea>

--- a/src/components/newsletter-popup/newsletter-popup.astro
+++ b/src/components/newsletter-popup/newsletter-popup.astro
@@ -5,7 +5,7 @@ import "./newsletter-popup.css";
 <div class="newsletter-popup-overlay" id="newsletter-popup-overlay" role="dialog" aria-modal="true" aria-labelledby="newsletter-popup-heading" aria-hidden="true">
   <div class="newsletter-popup">
     <div class="newsletter-popup-header">
-      <p class="newsletter-popup-heading" id="newsletter-popup-heading">📬 Get new roast reviews direct to your inbox</p>
+      <h2 class="newsletter-popup-heading" id="newsletter-popup-heading">📬 Get new roast reviews direct to your inbox</h2>
       <button class="newsletter-popup-close" id="newsletter-popup-close" aria-label="Close newsletter signup">×</button>
     </div>
     <iframe

--- a/src/components/sunday-roast-planner/sunday-roast-planner.tsx
+++ b/src/components/sunday-roast-planner/sunday-roast-planner.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "@clerk/astro/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Post } from "../../types";
 import WishlistButton from "../wishlist-button/wishlist-button.tsx";
 import "./sunday-roast-planner.css";
@@ -45,6 +45,8 @@ const SundayRoastPlanner = ({
   const { isSignedIn, isLoaded } = useAuth();
   const [savedSlugs, setSavedSlugs] = useState<Set<string>>(new Set());
   const [step, setStep] = useState<Step>(1);
+  const [announcement, setAnnouncement] = useState("");
+  const isFirstRender = useRef(true);
   const [locationType, setLocationType] = useState<LocationType>("area");
   const [area, setArea] = useState("");
   const [borough, setBorough] = useState("");
@@ -137,6 +139,23 @@ const SundayRoastPlanner = ({
       .slice(0, 3);
   }, [step, openPosts, locationType, area, borough, tubeLine, budget, minRating, inflationIndex]);
 
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (step === 1) setAnnouncement("Step 1 of 3: Where do you want to eat?");
+    else if (step === 2) setAnnouncement("Step 2 of 3: What's your budget?");
+    else if (step === 3) setAnnouncement("Step 3 of 3: What's the minimum rating you'll accept?");
+    else if (step === "results") {
+      setAnnouncement(
+        results.length === 0
+          ? "No matching roasts found. Try relaxing your filters."
+          : `${results.length === 1 ? "Your top pick is" : `Your top ${results.length} picks are`} ready.`
+      );
+    }
+  }, [step, results]);
+
   const updateUrl = useCallback((lt: LocationType, a: string, bo: string, tl: string, b: string, r: string) => {
     const params = new URLSearchParams();
     if (lt === "borough" && bo) params.set("borough", bo);
@@ -193,6 +212,9 @@ const SundayRoastPlanner = ({
 
   return (
     <div className="planner">
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
       {step === 1 && (
         <div className="planner__step">
           <p className="planner__step-label">Step 1 of 3</p>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -221,6 +221,7 @@ const reviewStructuredData =
     {contentType === "post" && (
       <>
         <button
+          type="button"
           class="skip"
           onclick="
             const el = document.getElementById('summary');

--- a/src/pages/chains/[chain].astro
+++ b/src/pages/chains/[chain].astro
@@ -73,7 +73,10 @@ const averageRating =
     : null;
 ---
 
-<BaseLayout pageTitle={`Roast Dinner Reviews by ${chainName}`}>
+<BaseLayout
+  pageTitle={`Roast Dinner Reviews by ${chainName}`}
+  description={`${posts.length === 1 ? "1 roast dinner review" : `${posts.length} roast dinner reviews`} of ${chainName} venues in London.${averageRating ? ` Average rating: ${averageRating}/10.` : ""}`}
+>
   <div class="no-image-container">
     <section class="post-title centre-with-padding">
       <h2>Reviews of venues owned by {chainName}</h2>


### PR DESCRIPTION
## Summary

Thursday's scheduled accessibility & SEO pass. Eight targeted fixes across 8 files — no behaviour changes, no visual regressions.

### Accessibility

- **newsletter-popup**: Promoted the dialog label element from `<p>` to `<h2>`. The `aria-labelledby` link still works either way, but a `<p>` is invisible to heading-navigation users; an `<h2>` is not. Existing CSS (`font-size`, `font-weight`, `margin: 0`) keeps the visual appearance identical.
- **comments + add-comment**: Added `autocomplete="name"` and `autocomplete="email"` to all comment form inputs. Required by WCAG 1.3.5 (Identify Input Purpose) for forms that collect personal information.
- **best-posts-list**: Added `width="400"`, `height="300"`, and `loading="lazy"` to the featured images. Without explicit dimensions the browser has no aspect-ratio information before the image loads, causing layout shift (CLS). `loading="lazy"` defers off-screen images.
- **sunday-roast-planner**: Added a visually-hidden `aria-live="polite"` region and a `useEffect` that announces the current step or result count whenever the wizard advances. Screen reader users previously got no feedback when the step content changed. A `useRef` guard prevents the announcement firing on the initial render (when step 1 is already visible).
- **[slug].astro**: Added `type="button"` to the "Skip The Nonsense" button. Not inside a form so there's no functional risk, but explicit `type` is best practice and avoids any future ambiguity.

### SEO

- **chains/[chain].astro**: Each chain page was falling back to the generic site description. Now passes a specific description to `BaseLayout` derived from the chain name, review count, and average rating (e.g. *"12 roast dinner reviews of Hawksmoor venues in London. Average rating: 8.2/10."*).
- **robots.txt**: Added `Disallow` rules for `/flags` (internal feature-flag admin), `/sign-in`, and `/api/`. These pages have no value in search indices and the flag admin page in particular should not be crawled.

## Test plan

- [ ] Newsletter popup: open the popup, confirm the heading is announced as a heading by a screen reader (or check with browser a11y inspector)
- [ ] Comment form: verify `autocomplete` attributes appear in rendered HTML
- [ ] Best posts list: inspect images in devtools — confirm `width`, `height`, `loading` attributes are present
- [ ] Sunday Roast Planner: navigate steps with a screen reader; confirm step announcements fire on each Next/Back click
- [ ] chains/[chain].astro: view source on a chain page (e.g. `/chains/hawksmoor`); confirm `<meta name="description">` is chain-specific
- [ ] robots.txt: visit `/robots.txt` and confirm the new Disallow lines are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bpjfD8iNUQXdBTK4E6qm7

---
_Generated by [Claude Code](https://claude.ai/code/session_011bpjfD8iNUQXdBTK4E6qm7)_