### PR TITLE
Add Best Value Roast Dinners in London page

### DIFF
--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { Post } from "../../types";
+import BestValue from "./best-value";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const createPost = ({
+  title,
+  slug,
+  rating,
+  price,
+  meat,
+  area,
+  borough,
+  tubeLine,
+  year,
+}: {
+  title: string;
+  slug: string;
+  rating: string;
+  price: string;
+  meat: string;
+  area: string;
+  borough: string;
+  tubeLine: string;
+  year: string;
+}): Post => ({
+  date: "2026-01-01",
+  title,
+  slug,
+  ratings: { nodes: [{ name: rating }] },
+  prices: { nodes: [{ name: price }] },
+  meats: { nodes: [{ name: meat }] },
+  areas: { nodes: [{ name: area }] },
+  boroughs: { nodes: [{ name: borough }] },
+  tubeLines: { nodes: [{ name: tubeLine }] },
+  yearsOfVisit: { nodes: [{ name: year }] },
+});
+
+const posts: Post[] = [
+  createPost({
+    title: "Cheap And Great",
+    slug: "cheap-and-great",
+    rating: "9",
+    price: "£12",
+    meat: "Beef",
+    area: "Soho",
+    borough: "Westminster",
+    tubeLine: "Central",
+    year: "2024",
+  }),
+  createPost({
+    title: "Pricey And Mediocre",
+    slug: "pricey-and-mediocre",
+    rating: "6",
+    price: "£30",
+    meat: "Pork",
+    area: "Camden",
+    borough: "Camden",
+    tubeLine: "Northern",
+    year: "2024",
+  }),
+];
+
+const createHost = () => {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  return { host, root };
+};
+
+const waitForRender = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+const getVenueNames = (host: HTMLDivElement) =>
+  Array.from(host.querySelectorAll('[data-test-id="value-link"]')).map((el) => (el.textContent ?? "").trim());
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  window.history.replaceState(null, "", "/");
+});
+
+describe("best-value component", () => {
+  test("ranks venues by value score (rating / price) descending by default", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great", "Pricey And Mediocre"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("filters by meat and clears filters", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    const meatFilter = host.querySelector('select[name="meat"]') as HTMLSelectElement;
+    await act(async () => {
+      meatFilter.value = "Pork";
+      meatFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Pricey And Mediocre"]);
+
+    const clearButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Clear All Filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      clearButton.click();
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great", "Pricey And Mediocre"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("applies inflation-adjusted prices when computing the displayed value score", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={posts} inflationIndex={{ "2024": 2 }} mostRecentYear="2024" />);
+    });
+    await waitForRender();
+
+    const prices = Array.from(host.querySelectorAll('[data-test-id="value-price"]')).map(
+      (el) => el.textContent
+    );
+
+    expect(prices).toContain("~£24.00");
+    expect(prices).toContain("~£60.00");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -116,6 +116,15 @@ describe("best-value component", () => {
     });
     await waitForRender();
 
+    const showOptionsButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show all options / filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      showOptionsButton.click();
+    });
+    await waitForRender();
+
     const areaFilter = host.querySelector('select[name="area"]') as HTMLSelectElement;
     await act(async () => {
       areaFilter.value = "Camden";

--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -108,7 +108,7 @@ describe("best-value component", () => {
     });
   });
 
-  test("filters by meat and clears filters", async () => {
+  test("filters by area and clears filters", async () => {
     const { host, root } = createHost();
 
     await act(async () => {
@@ -116,10 +116,10 @@ describe("best-value component", () => {
     });
     await waitForRender();
 
-    const meatFilter = host.querySelector('select[name="meat"]') as HTMLSelectElement;
+    const areaFilter = host.querySelector('select[name="area"]') as HTMLSelectElement;
     await act(async () => {
-      meatFilter.value = "Pork";
-      meatFilter.dispatchEvent(new Event("change", { bubbles: true }));
+      areaFilter.value = "Camden";
+      areaFilter.dispatchEvent(new Event("change", { bubbles: true }));
     });
     await waitForRender();
 

--- a/src/components/best-value/best-value.tsx
+++ b/src/components/best-value/best-value.tsx
@@ -17,23 +17,9 @@ const BestValue = ({
 }) => {
   const scoredPosts = useMemo(() => computeValueScores(posts, inflationIndex), [posts, inflationIndex]);
 
-  const {
-    sortOrder,
-    sortColumn,
-    filters,
-    handleSortChange,
-    toggleSortOrder,
-    handleFilterChange,
-    clearFilters,
-    copyShareableLink,
-    copied,
-    sortedPosts,
-  } = useValueFilter(scoredPosts);
+  const { filters, handleFilterChange, clearFilters, copyShareableLink, copied, sortedPosts } =
+    useValueFilter(scoredPosts);
 
-  const uniqueMeats = useMemo(
-    () => getUniqueValues(posts, (post) => post.meats?.nodes[0]?.name),
-    [posts]
-  );
   const uniqueAreas = useMemo(
     () => getUniqueValues(posts, (post) => post.areas?.nodes[0]?.name),
     [posts]
@@ -50,25 +36,9 @@ const BestValue = ({
     [posts]
   );
 
-  const maxPrice = useMemo(
-    () => Math.max(1, ...scoredPosts.map((scored) => scored.adjustedPrice)),
-    [scoredPosts]
-  );
-
   return (
     <div className="best-value-container">
       <div className="filter-posts">
-        <div>
-          <label htmlFor="meat-filter">Filter by Meat: </label>
-          <select id="meat-filter" name="meat" value={filters.meat} onChange={handleFilterChange}>
-            <option value="">All</option>
-            {uniqueMeats.map((meat) => (
-              <option key={meat} value={meat}>
-                {meat}
-              </option>
-            ))}
-          </select>
-        </div>
         <div>
           <label htmlFor="area-filter">Filter by Area: </label>
           <select id="area-filter" name="area" value={filters.area} onChange={handleFilterChange}>
@@ -104,19 +74,6 @@ const BestValue = ({
         </div>
       </div>
 
-      <div className="sort-posts">
-        <label htmlFor="sort-column">Sort by: </label>
-        <select id="sort-column" onChange={handleSortChange} value={sortColumn}>
-          <option value="valueScore">Value Score</option>
-          <option value="rating">Rating</option>
-          <option value="price">Price (inflation-adjusted)</option>
-          <option value="title">Name</option>
-        </select>
-        <button type="button" onClick={toggleSortOrder}>
-          {sortOrder === "asc" ? "Sort Descending" : "Sort Ascending"}
-        </button>
-      </div>
-
       <button type="button" className="clear-button" onClick={clearFilters}>
         Clear All Filters
       </button>
@@ -129,51 +86,13 @@ const BestValue = ({
         {mostRecentYear ? ` (shown in ${mostRecentYear} money)` : ""}. Higher is better value.
       </p>
 
-      <div className="value-scatter">
-        <svg
-          viewBox="0 0 320 220"
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          aria-labelledby="value-scatter-title"
-        >
-          <title id="value-scatter-title">
-            Scatter plot of inflation-adjusted price versus rating for every venue
-          </title>
-          <line x1="30" y1="10" x2="30" y2="200" className="axis-line" />
-          <line x1="30" y1="200" x2="310" y2="200" className="axis-line" />
-          <text x="4" y="14" className="axis-label">
-            10
-          </text>
-          <text x="10" y="212" className="axis-label">
-            0
-          </text>
-          <text x="270" y="216" className="axis-label">
-            ~£{Math.round(maxPrice)}
-          </text>
-          {sortedPosts.map(({ post, adjustedPrice, rating, valueScore }) => {
-            const x = 30 + (adjustedPrice / maxPrice) * 270;
-            const y = 200 - (rating / 10) * 190;
-            return (
-              <a key={post.slug} href={`/${post.slug}`}>
-                <circle cx={x} cy={y} r={3 + Math.min(6, valueScore * 2)} className="value-dot">
-                  <title>
-                    {post.title}: {rating}/10 for ~£{adjustedPrice.toFixed(2)} (value score{" "}
-                    {valueScore.toFixed(2)})
-                  </title>
-                </circle>
-              </a>
-            );
-          })}
-        </svg>
-      </div>
-
       <table className="value-table">
         <caption className="visually-hidden">Roast dinners ranked by value score</caption>
         <thead>
           <tr>
             <th scope="col">Venue</th>
             <th scope="col">Rating</th>
-            <th scope="col">Price</th>
+            <th scope="col">Price (inflation-adjusted{mostRecentYear ? `, ${mostRecentYear} money` : ""})</th>
             <th scope="col">Value Score</th>
             <th scope="col">Area</th>
           </tr>

--- a/src/components/best-value/best-value.tsx
+++ b/src/components/best-value/best-value.tsx
@@ -1,0 +1,201 @@
+import { useMemo } from "react";
+import { computeValueScores } from "../../lib/valueScore";
+import type { Post } from "../../types";
+import { useValueFilter } from "./useValueFilter";
+
+const getUniqueValues = (posts: Post[], accessor: (post: Post) => string | undefined): string[] =>
+  Array.from(new Set(posts.map(accessor))).filter((v): v is string => v !== undefined && v !== "").sort();
+
+const BestValue = ({
+  posts,
+  inflationIndex = {},
+  mostRecentYear = "",
+}: {
+  posts: Post[];
+  inflationIndex?: Record<string, number>;
+  mostRecentYear?: string;
+}) => {
+  const scoredPosts = useMemo(() => computeValueScores(posts, inflationIndex), [posts, inflationIndex]);
+
+  const {
+    sortOrder,
+    sortColumn,
+    filters,
+    handleSortChange,
+    toggleSortOrder,
+    handleFilterChange,
+    clearFilters,
+    copyShareableLink,
+    copied,
+    sortedPosts,
+  } = useValueFilter(scoredPosts);
+
+  const uniqueMeats = useMemo(
+    () => getUniqueValues(posts, (post) => post.meats?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueAreas = useMemo(
+    () => getUniqueValues(posts, (post) => post.areas?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueBoroughs = useMemo(
+    () => getUniqueValues(posts, (post) => post.boroughs?.nodes[0]?.name),
+    [posts]
+  );
+  const uniqueTubeLines = useMemo(
+    () =>
+      Array.from(new Set(posts.flatMap((post) => post.tubeLines?.nodes.map((node) => node.name) ?? [])))
+        .filter((v): v is string => Boolean(v))
+        .sort(),
+    [posts]
+  );
+
+  const maxPrice = useMemo(
+    () => Math.max(1, ...scoredPosts.map((scored) => scored.adjustedPrice)),
+    [scoredPosts]
+  );
+
+  return (
+    <div className="best-value-container">
+      <div className="filter-posts">
+        <div>
+          <label htmlFor="meat-filter">Filter by Meat: </label>
+          <select id="meat-filter" name="meat" value={filters.meat} onChange={handleFilterChange}>
+            <option value="">All</option>
+            {uniqueMeats.map((meat) => (
+              <option key={meat} value={meat}>
+                {meat}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="area-filter">Filter by Area: </label>
+          <select id="area-filter" name="area" value={filters.area} onChange={handleFilterChange}>
+            <option value="">All</option>
+            {uniqueAreas.map((area) => (
+              <option key={area} value={area}>
+                {area}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="borough-filter">Filter by Borough: </label>
+          <select id="borough-filter" name="borough" value={filters.borough} onChange={handleFilterChange}>
+            <option value="">All</option>
+            {uniqueBoroughs.map((borough) => (
+              <option key={borough} value={borough}>
+                {borough}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="tube-line-filter">Filter by Tube Line: </label>
+          <select id="tube-line-filter" name="tubeLine" value={filters.tubeLine} onChange={handleFilterChange}>
+            <option value="">All</option>
+            {uniqueTubeLines.map((line) => (
+              <option key={line} value={line}>
+                {line}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="sort-posts">
+        <label htmlFor="sort-column">Sort by: </label>
+        <select id="sort-column" onChange={handleSortChange} value={sortColumn}>
+          <option value="valueScore">Value Score</option>
+          <option value="rating">Rating</option>
+          <option value="price">Price (inflation-adjusted)</option>
+          <option value="title">Name</option>
+        </select>
+        <button type="button" onClick={toggleSortOrder}>
+          {sortOrder === "asc" ? "Sort Descending" : "Sort Ascending"}
+        </button>
+      </div>
+
+      <button type="button" className="clear-button" onClick={clearFilters}>
+        Clear All Filters
+      </button>
+      <button type="button" className="share-button" onClick={copyShareableLink}>
+        {copied ? "Copied!" : "Copy shareable link"}
+      </button>
+
+      <p className="value-score-note">
+        Value score = rating &divide; inflation-adjusted price
+        {mostRecentYear ? ` (shown in ${mostRecentYear} money)` : ""}. Higher is better value.
+      </p>
+
+      <div className="value-scatter">
+        <svg
+          viewBox="0 0 320 220"
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          aria-labelledby="value-scatter-title"
+        >
+          <title id="value-scatter-title">
+            Scatter plot of inflation-adjusted price versus rating for every venue
+          </title>
+          <line x1="30" y1="10" x2="30" y2="200" className="axis-line" />
+          <line x1="30" y1="200" x2="310" y2="200" className="axis-line" />
+          <text x="4" y="14" className="axis-label">
+            10
+          </text>
+          <text x="10" y="212" className="axis-label">
+            0
+          </text>
+          <text x="270" y="216" className="axis-label">
+            ~£{Math.round(maxPrice)}
+          </text>
+          {sortedPosts.map(({ post, adjustedPrice, rating, valueScore }) => {
+            const x = 30 + (adjustedPrice / maxPrice) * 270;
+            const y = 200 - (rating / 10) * 190;
+            return (
+              <a key={post.slug} href={`/${post.slug}`}>
+                <circle cx={x} cy={y} r={3 + Math.min(6, valueScore * 2)} className="value-dot">
+                  <title>
+                    {post.title}: {rating}/10 for ~£{adjustedPrice.toFixed(2)} (value score{" "}
+                    {valueScore.toFixed(2)})
+                  </title>
+                </circle>
+              </a>
+            );
+          })}
+        </svg>
+      </div>
+
+      <table className="value-table">
+        <caption className="visually-hidden">Roast dinners ranked by value score</caption>
+        <thead>
+          <tr>
+            <th scope="col">Venue</th>
+            <th scope="col">Rating</th>
+            <th scope="col">Price</th>
+            <th scope="col">Value Score</th>
+            <th scope="col">Area</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedPosts.map(({ post, adjustedPrice, rating, valueScore }) => (
+            <tr key={post.slug}>
+              <td>
+                <a href={`/${post.slug}`} data-test-id="value-link">
+                  {post.title}
+                </a>
+              </td>
+              <td data-test-id="value-rating">{rating}</td>
+              <td data-test-id="value-price">~£{adjustedPrice.toFixed(2)}</td>
+              <td data-test-id="value-score">{valueScore.toFixed(2)}</td>
+              <td data-test-id="value-area">{post.areas?.nodes[0]?.name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default BestValue;

--- a/src/components/best-value/best-value.tsx
+++ b/src/components/best-value/best-value.tsx
@@ -17,8 +17,16 @@ const BestValue = ({
 }) => {
   const scoredPosts = useMemo(() => computeValueScores(posts, inflationIndex), [posts, inflationIndex]);
 
-  const { filters, handleFilterChange, clearFilters, copyShareableLink, copied, sortedPosts } =
-    useValueFilter(scoredPosts);
+  const {
+    filters,
+    showOptions,
+    setShowOptions,
+    handleFilterChange,
+    clearFilters,
+    copyShareableLink,
+    copied,
+    sortedPosts,
+  } = useValueFilter(scoredPosts);
 
   const uniqueAreas = useMemo(
     () => getUniqueValues(posts, (post) => post.areas?.nodes[0]?.name),
@@ -38,48 +46,75 @@ const BestValue = ({
 
   return (
     <div className="best-value-container">
-      <div className="filter-posts">
-        <div>
-          <label htmlFor="area-filter">Filter by Area: </label>
-          <select id="area-filter" name="area" value={filters.area} onChange={handleFilterChange}>
-            <option value="">All</option>
-            {uniqueAreas.map((area) => (
-              <option key={area} value={area}>
-                {area}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label htmlFor="borough-filter">Filter by Borough: </label>
-          <select id="borough-filter" name="borough" value={filters.borough} onChange={handleFilterChange}>
-            <option value="">All</option>
-            {uniqueBoroughs.map((borough) => (
-              <option key={borough} value={borough}>
-                {borough}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label htmlFor="tube-line-filter">Filter by Tube Line: </label>
-          <select id="tube-line-filter" name="tubeLine" value={filters.tubeLine} onChange={handleFilterChange}>
-            <option value="">All</option>
-            {uniqueTubeLines.map((line) => (
-              <option key={line} value={line}>
-                {line}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
+      <p>
+        The value rankings are fully customisable, you can filter by area, borough or tube line. Click
+        to show all options.
+      </p>
+      <button
+        type="button"
+        className="show-hide-button"
+        onClick={() => setShowOptions((prev) => !prev)}
+        aria-expanded={showOptions}
+        aria-controls="value-options-panel"
+      >
+        {showOptions ? "Hide options" : "Show all options / filters"}
+      </button>
+      {showOptions && (
+        <div id="value-options-panel">
+          <div className="filter-posts">
+            <div>
+              <label htmlFor="area-filter">Filter by Area: </label>
+              <select id="area-filter" name="area" value={filters.area} onChange={handleFilterChange}>
+                <option value="">All</option>
+                {uniqueAreas.map((area) => (
+                  <option key={area} value={area}>
+                    {area}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="borough-filter">Filter by Borough: </label>
+              <select
+                id="borough-filter"
+                name="borough"
+                value={filters.borough}
+                onChange={handleFilterChange}
+              >
+                <option value="">All</option>
+                {uniqueBoroughs.map((borough) => (
+                  <option key={borough} value={borough}>
+                    {borough}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="tube-line-filter">Filter by Tube Line: </label>
+              <select
+                id="tube-line-filter"
+                name="tubeLine"
+                value={filters.tubeLine}
+                onChange={handleFilterChange}
+              >
+                <option value="">All</option>
+                {uniqueTubeLines.map((line) => (
+                  <option key={line} value={line}>
+                    {line}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
 
-      <button type="button" className="clear-button" onClick={clearFilters}>
-        Clear All Filters
-      </button>
-      <button type="button" className="share-button" onClick={copyShareableLink}>
-        {copied ? "Copied!" : "Copy shareable link"}
-      </button>
+          <button type="button" className="clear-button" onClick={clearFilters}>
+            Clear All Filters
+          </button>
+          <button type="button" className="share-button" onClick={copyShareableLink}>
+            {copied ? "Copied!" : "Copy shareable link"}
+          </button>
+        </div>
+      )}
 
       <p className="value-score-note">
         Value score = rating &divide; inflation-adjusted price
@@ -92,9 +127,8 @@ const BestValue = ({
           <tr>
             <th scope="col">Venue</th>
             <th scope="col">Rating</th>
-            <th scope="col">Price (inflation-adjusted{mostRecentYear ? `, ${mostRecentYear} money` : ""})</th>
+            <th scope="col">Adjusted Price</th>
             <th scope="col">Value Score</th>
-            <th scope="col">Area</th>
           </tr>
         </thead>
         <tbody>
@@ -108,7 +142,6 @@ const BestValue = ({
               <td data-test-id="value-rating">{rating}</td>
               <td data-test-id="value-price">~£{adjustedPrice.toFixed(2)}</td>
               <td data-test-id="value-score">{valueScore.toFixed(2)}</td>
-              <td data-test-id="value-area">{post.areas?.nodes[0]?.name}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/best-value/useValueFilter.tsx
+++ b/src/components/best-value/useValueFilter.tsx
@@ -1,0 +1,154 @@
+import { type ChangeEvent, useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import type { ValueScoredPost } from "../../lib/valueScore";
+
+type FilterState = {
+  meat: string;
+  area: string;
+  borough: string;
+  tubeLine: string;
+};
+
+type FilterAction =
+  | { type: "SET_FILTER"; name: keyof FilterState; value: string }
+  | { type: "CLEAR_FILTERS" };
+
+const initialFilterState: FilterState = {
+  meat: "",
+  area: "",
+  borough: "",
+  tubeLine: "",
+};
+
+const filterReducer = (state: FilterState, action: FilterAction): FilterState => {
+  switch (action.type) {
+    case "SET_FILTER":
+      return { ...state, [action.name]: action.value };
+    case "CLEAR_FILTERS":
+      return initialFilterState;
+  }
+};
+
+const getInitialStateFromUrl = (): URLSearchParams | null => {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search);
+};
+
+export type ValueSortColumn = "valueScore" | "rating" | "price" | "title";
+
+const filterScoredPosts = (scoredPosts: ValueScoredPost[], filters: FilterState): ValueScoredPost[] =>
+  scoredPosts.filter(({ post }) => {
+    const meat = post.meats?.nodes[0]?.name ?? "";
+    const area = post.areas?.nodes[0]?.name ?? "";
+    const borough = post.boroughs?.nodes[0]?.name ?? "";
+    const tubeLines = post.tubeLines?.nodes.map((node) => node.name) ?? [];
+
+    return (
+      (filters.meat ? meat === filters.meat : true) &&
+      (filters.area ? area === filters.area : true) &&
+      (filters.borough ? borough === filters.borough : true) &&
+      (filters.tubeLine ? tubeLines.includes(filters.tubeLine) : true)
+    );
+  });
+
+const sortScoredPosts = (
+  scoredPosts: ValueScoredPost[],
+  column: ValueSortColumn,
+  order: "asc" | "desc"
+): ValueScoredPost[] =>
+  [...scoredPosts].sort((a, b) => {
+    let aValue: number | string;
+    let bValue: number | string;
+
+    switch (column) {
+      case "rating":
+        aValue = a.rating;
+        bValue = b.rating;
+        break;
+      case "price":
+        aValue = a.adjustedPrice;
+        bValue = b.adjustedPrice;
+        break;
+      case "title":
+        aValue = a.post.title ?? "";
+        bValue = b.post.title ?? "";
+        break;
+      default:
+        aValue = a.valueScore;
+        bValue = b.valueScore;
+    }
+
+    if (aValue < bValue) return order === "asc" ? -1 : 1;
+    if (aValue > bValue) return order === "asc" ? 1 : -1;
+    return 0;
+  });
+
+export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
+  const urlParams = getInitialStateFromUrl();
+
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(
+    urlParams?.get("order") === "asc" ? "asc" : "desc"
+  );
+  const [sortColumn, setSortColumn] = useState<ValueSortColumn>(
+    (urlParams?.get("sort") as ValueSortColumn) ?? "valueScore"
+  );
+  const [filters, dispatch] = useReducer(filterReducer, {
+    meat: urlParams?.get("meat") ?? "",
+    area: urlParams?.get("area") ?? "",
+    borough: urlParams?.get("borough") ?? "",
+    tubeLine: urlParams?.get("tubeLine") ?? "",
+  });
+
+  const handleSortChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    setSortColumn(e.target.value as ValueSortColumn);
+  }, []);
+
+  const toggleSortOrder = useCallback((): void => {
+    setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+  }, []);
+
+  const handleFilterChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
+  }, []);
+
+  const clearFilters = useCallback((): void => {
+    dispatch({ type: "CLEAR_FILTERS" });
+  }, []);
+
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (sortColumn !== "valueScore") params.set("sort", sortColumn);
+    if (sortOrder !== "desc") params.set("order", sortOrder);
+    for (const [key, value] of Object.entries(filters)) {
+      if (value) params.set(key, value);
+    }
+    const query = params.toString();
+    window.history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
+  }, [sortColumn, sortOrder, filters]);
+
+  const copyShareableLink = useCallback(() => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
+
+  const sortedPosts = useMemo(
+    () => sortScoredPosts(filterScoredPosts(scoredPosts, filters), sortColumn, sortOrder),
+    [scoredPosts, filters, sortColumn, sortOrder]
+  );
+
+  return {
+    sortOrder,
+    sortColumn,
+    filters,
+    handleSortChange,
+    toggleSortOrder,
+    handleFilterChange,
+    clearFilters,
+    copyShareableLink,
+    copied,
+    sortedPosts,
+  };
+};

--- a/src/components/best-value/useValueFilter.tsx
+++ b/src/components/best-value/useValueFilter.tsx
@@ -2,7 +2,6 @@ import { type ChangeEvent, useCallback, useEffect, useMemo, useReducer, useState
 import type { ValueScoredPost } from "../../lib/valueScore";
 
 type FilterState = {
-  meat: string;
   area: string;
   borough: string;
   tubeLine: string;
@@ -13,7 +12,6 @@ type FilterAction =
   | { type: "CLEAR_FILTERS" };
 
 const initialFilterState: FilterState = {
-  meat: "",
   area: "",
   borough: "",
   tubeLine: "",
@@ -33,78 +31,30 @@ const getInitialStateFromUrl = (): URLSearchParams | null => {
   return new URLSearchParams(window.location.search);
 };
 
-export type ValueSortColumn = "valueScore" | "rating" | "price" | "title";
-
 const filterScoredPosts = (scoredPosts: ValueScoredPost[], filters: FilterState): ValueScoredPost[] =>
   scoredPosts.filter(({ post }) => {
-    const meat = post.meats?.nodes[0]?.name ?? "";
     const area = post.areas?.nodes[0]?.name ?? "";
     const borough = post.boroughs?.nodes[0]?.name ?? "";
     const tubeLines = post.tubeLines?.nodes.map((node) => node.name) ?? [];
 
     return (
-      (filters.meat ? meat === filters.meat : true) &&
       (filters.area ? area === filters.area : true) &&
       (filters.borough ? borough === filters.borough : true) &&
       (filters.tubeLine ? tubeLines.includes(filters.tubeLine) : true)
     );
   });
 
-const sortScoredPosts = (
-  scoredPosts: ValueScoredPost[],
-  column: ValueSortColumn,
-  order: "asc" | "desc"
-): ValueScoredPost[] =>
-  [...scoredPosts].sort((a, b) => {
-    let aValue: number | string;
-    let bValue: number | string;
-
-    switch (column) {
-      case "rating":
-        aValue = a.rating;
-        bValue = b.rating;
-        break;
-      case "price":
-        aValue = a.adjustedPrice;
-        bValue = b.adjustedPrice;
-        break;
-      case "title":
-        aValue = a.post.title ?? "";
-        bValue = b.post.title ?? "";
-        break;
-      default:
-        aValue = a.valueScore;
-        bValue = b.valueScore;
-    }
-
-    if (aValue < bValue) return order === "asc" ? -1 : 1;
-    if (aValue > bValue) return order === "asc" ? 1 : -1;
-    return 0;
-  });
+const sortByValueScoreDesc = (scoredPosts: ValueScoredPost[]): ValueScoredPost[] =>
+  [...scoredPosts].sort((a, b) => b.valueScore - a.valueScore);
 
 export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
   const urlParams = getInitialStateFromUrl();
 
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">(
-    urlParams?.get("order") === "asc" ? "asc" : "desc"
-  );
-  const [sortColumn, setSortColumn] = useState<ValueSortColumn>(
-    (urlParams?.get("sort") as ValueSortColumn) ?? "valueScore"
-  );
   const [filters, dispatch] = useReducer(filterReducer, {
-    meat: urlParams?.get("meat") ?? "",
     area: urlParams?.get("area") ?? "",
     borough: urlParams?.get("borough") ?? "",
     tubeLine: urlParams?.get("tubeLine") ?? "",
   });
-
-  const handleSortChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-    setSortColumn(e.target.value as ValueSortColumn);
-  }, []);
-
-  const toggleSortOrder = useCallback((): void => {
-    setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
-  }, []);
 
   const handleFilterChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
     dispatch({ type: "SET_FILTER", name: e.target.name as keyof FilterState, value: e.target.value });
@@ -118,14 +68,12 @@ export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
 
   useEffect(() => {
     const params = new URLSearchParams();
-    if (sortColumn !== "valueScore") params.set("sort", sortColumn);
-    if (sortOrder !== "desc") params.set("order", sortOrder);
     for (const [key, value] of Object.entries(filters)) {
       if (value) params.set(key, value);
     }
     const query = params.toString();
     window.history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
-  }, [sortColumn, sortOrder, filters]);
+  }, [filters]);
 
   const copyShareableLink = useCallback(() => {
     navigator.clipboard.writeText(window.location.href).then(() => {
@@ -135,16 +83,12 @@ export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
   }, []);
 
   const sortedPosts = useMemo(
-    () => sortScoredPosts(filterScoredPosts(scoredPosts, filters), sortColumn, sortOrder),
-    [scoredPosts, filters, sortColumn, sortOrder]
+    () => sortByValueScoreDesc(filterScoredPosts(scoredPosts, filters)),
+    [scoredPosts, filters]
   );
 
   return {
-    sortOrder,
-    sortColumn,
     filters,
-    handleSortChange,
-    toggleSortOrder,
     handleFilterChange,
     clearFilters,
     copyShareableLink,

--- a/src/components/best-value/useValueFilter.tsx
+++ b/src/components/best-value/useValueFilter.tsx
@@ -64,6 +64,7 @@ export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
     dispatch({ type: "CLEAR_FILTERS" });
   }, []);
 
+  const [showOptions, setShowOptions] = useState(false);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -89,6 +90,8 @@ export const useValueFilter = (scoredPosts: ValueScoredPost[]) => {
 
   return {
     filters,
+    showOptions,
+    setShowOptions,
     handleFilterChange,
     clearFilters,
     copyShareableLink,

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -54,6 +54,7 @@ const isTesting = import.meta.env.PLAYWRIGHT === "true";
 
     <nav id="nav-menu" aria-label="Main navigation">
       <a href="/league-of-roasts">League Of Roasts</a>
+      <a href="/best-value-roast-dinners-london">Best Value Roasts</a>
       <a href="/best-roast-lists">Best Roasts Lists</a>
       <a href="/maps">Maps</a>
       <a href="/to-do-list">To-Do List</a>

--- a/src/lib/valueScore.test.ts
+++ b/src/lib/valueScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import type { Post } from "../types";
+import { computeValueScores } from "./valueScore";
+
+const createPost = ({
+  title,
+  rating,
+  price,
+  year,
+}: {
+  title: string;
+  rating: string;
+  price: string;
+  year?: string;
+}): Post => ({
+  date: "2026-01-01",
+  title,
+  slug: title.toLowerCase().replace(/\s+/g, "-"),
+  ratings: { nodes: [{ name: rating }] },
+  prices: { nodes: [{ name: price }] },
+  ...(year ? { yearsOfVisit: { nodes: [{ name: year }] } } : {}),
+});
+
+describe("computeValueScores", () => {
+  test("computes value score as rating divided by raw price when no inflation data applies", () => {
+    const posts = [createPost({ title: "Cheap Good Roast", rating: "8", price: "£10" })];
+
+    const [scored] = computeValueScores(posts, {});
+
+    expect(scored.rawPrice).toBe(10);
+    expect(scored.adjustedPrice).toBe(10);
+    expect(scored.valueScore).toBe(0.8);
+  });
+
+  test("applies the inflation multiplier for the post's visit year to the price", () => {
+    const posts = [createPost({ title: "Old Cheap Roast", rating: "8", price: "£10", year: "2018" })];
+
+    const [scored] = computeValueScores(posts, { "2018": 1.5 });
+
+    expect(scored.adjustedPrice).toBe(15);
+    expect(scored.valueScore).toBeCloseTo(8 / 15);
+  });
+
+  test("excludes posts with missing or invalid rating or price", () => {
+    const posts = [
+      createPost({ title: "No Rating", rating: "", price: "£10" }),
+      createPost({ title: "No Price", rating: "8", price: "" }),
+      createPost({ title: "Zero Rating", rating: "0", price: "£10" }),
+      createPost({ title: "Valid", rating: "9", price: "£12" }),
+    ];
+
+    const scored = computeValueScores(posts, {});
+
+    expect(scored.map((s) => s.post.title)).toEqual(["Valid"]);
+  });
+});

--- a/src/lib/valueScore.ts
+++ b/src/lib/valueScore.ts
@@ -1,0 +1,44 @@
+import type { Post } from "../types";
+
+export type ValueScoredPost = {
+  post: Post;
+  rawPrice: number;
+  adjustedPrice: number;
+  rating: number;
+  valueScore: number;
+};
+
+const parsePrice = (priceStr: string | undefined): number | null => {
+  if (!priceStr) return null;
+  const match = priceStr.match(/[\d,.]+/);
+  if (!match) return null;
+  const price = Number.parseFloat(match[0].replace(",", ""));
+  return !Number.isNaN(price) && price > 0 ? price : null;
+};
+
+export function computeValueScores(
+  posts: Post[],
+  inflationIndex: Record<string, number>
+): ValueScoredPost[] {
+  const scored: ValueScoredPost[] = [];
+
+  for (const post of posts) {
+    const rating = Number.parseFloat(post.ratings?.nodes[0]?.name ?? "");
+    const rawPrice = parsePrice(post.prices?.nodes[0]?.name);
+    if (!rawPrice || Number.isNaN(rating) || rating <= 0) continue;
+
+    const year = post.yearsOfVisit?.nodes[0]?.name;
+    const multiplier = year ? inflationIndex[year] : undefined;
+    const adjustedPrice = multiplier ? rawPrice * multiplier : rawPrice;
+
+    scored.push({
+      post,
+      rawPrice,
+      adjustedPrice,
+      rating,
+      valueScore: rating / adjustedPrice,
+    });
+  }
+
+  return scored;
+}

--- a/src/pages/best-value-roast-dinners-london.astro
+++ b/src/pages/best-value-roast-dinners-london.astro
@@ -21,7 +21,10 @@ let endCursor: string | null = null;
 
 while (hasNextPage) {
   const variables: { after?: string } = endCursor ? { after: endCursor } : {};
-  const { posts } = await fetchGraphQL<{ posts: PostsConnection }>(GET_ALL_POSTS, variables);
+  const { posts } = await fetchGraphQL<{ posts: PostsConnection }>(
+    GET_ALL_POSTS,
+    variables
+  );
 
   allRoastPosts.push(
     ...posts.nodes.filter(
@@ -55,24 +58,31 @@ const valueListStructuredData = {
     "@type": "ListItem",
     position: idx + 1,
     name: post.title,
-    url: post.slug && Astro.site ? new URL(post.slug, Astro.site).href : undefined,
+    url:
+      post.slug && Astro.site ? new URL(post.slug, Astro.site).href : undefined,
   })),
 };
 ---
 
-<BaseLayout pageTitle={pageTitle} description={description} structuredData={valueListStructuredData}>
+<BaseLayout
+  pageTitle={pageTitle}
+  description={description}
+  structuredData={valueListStructuredData}
+>
   <FeaturedPostHeader imageSrc={logo3.src} title={pageTitle} />
   <div class="container league-container">
     <p>
-      A great roast dinner shouldn't have to cost a fortune. This page ranks every roast dinner I've
-      reviewed by value score — rating divided by an inflation-adjusted price — so a brilliant £14 roast
-      from 2019 gets compared fairly against a brilliant £22 roast today. If you're after a cheap roast
-      dinner in London that still hits the spot, or just fancy a roast dinner under £15, start here.
+      This page ranks every roast dinner I've reviewed by value score - rating
+      divided by an inflation-adjusted price - so a brilliant £14 roast from
+      2019 gets compared fairly against a brilliant £28 roast today. If you're
+      after a cheap roast dinner in London that still hits the spot, or just
+      fancy a roast dinner under £20 (maybe), start here.
     </p>
     <p>
-      Filter by area, borough or tube line to narrow it down, or just scroll the ranked table below. Every
-      price has been adjusted for roast dinner inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""},
-      so it doesn't matter when I visited — the comparison is fair.
+      Filter by area, borough or tube line to narrow it down, or just scroll the
+      ranked table below. Every price has been adjusted for roast dinner
+      inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""}, so it
+      doesn't matter when I visited — the comparison is fair.
     </p>
 
     <div class="sort-posts-loading" id="best-value-loading">
@@ -82,8 +92,16 @@ const valueListStructuredData = {
       </div>
     </div>
 
-    <div class="best-value-loading-container" style="opacity: 0; position: absolute; visibility: hidden;">
-      <BestValue client:only="react" posts={allRoastPosts} inflationIndex={inflationIndex} mostRecentYear={mostRecentYear} />
+    <div
+      class="best-value-loading-container"
+      style="opacity: 0; position: absolute; visibility: hidden;"
+    >
+      <BestValue
+        client:only="react"
+        posts={allRoastPosts}
+        inflationIndex={inflationIndex}
+        mostRecentYear={mostRecentYear}
+      />
     </div>
 
     <script lang="ts">
@@ -93,9 +111,13 @@ const valueListStructuredData = {
 
         const checkForComponent = () => {
           attempts++;
-          const bestValueElement = document.querySelector(".best-value-loading-container > div");
+          const bestValueElement = document.querySelector(
+            ".best-value-loading-container > div"
+          );
           const loadingElement = document.getElementById("best-value-loading");
-          const containerElement = document.querySelector(".best-value-loading-container");
+          const containerElement = document.querySelector(
+            ".best-value-loading-container"
+          );
 
           if (bestValueElement && loadingElement && containerElement) {
             loadingElement.style.display = "none";

--- a/src/pages/best-value-roast-dinners-london.astro
+++ b/src/pages/best-value-roast-dinners-london.astro
@@ -1,0 +1,129 @@
+---
+import BestValue from "../components/best-value/best-value.tsx";
+import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
+import Newsletter from "../components/newsletter/newsletter.astro";
+import logo3 from "../images/logo-3.png";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { computeInflationIndex } from "../lib/inflationIndex";
+import { computeValueScores } from "../lib/valueScore";
+import "../styles/post.css";
+import "../styles/best-value.css";
+import { fetchGraphQL } from "../lib/api";
+import GET_ALL_POSTS from "../lib/queries/getAllPosts";
+import type { Post, PostsConnection } from "../types";
+
+export const prerender = true;
+
+const allRoastPosts: Post[] = [];
+
+let hasNextPage = true;
+let endCursor: string | null = null;
+
+while (hasNextPage) {
+  const variables: { after?: string } = endCursor ? { after: endCursor } : {};
+  const { posts } = await fetchGraphQL<{ posts: PostsConnection }>(GET_ALL_POSTS, variables);
+
+  allRoastPosts.push(
+    ...posts.nodes.filter(
+      (post: Post) =>
+        post.typesOfPost?.nodes.some((node: { name: string }) => node.name === "Roast Dinner") &&
+        !post.closedDowns?.nodes[0]?.name
+    )
+  );
+  hasNextPage = posts.pageInfo.hasNextPage;
+  endCursor = posts.pageInfo.endCursor;
+}
+
+const { inflationIndex, mostRecentYear } = computeInflationIndex(allRoastPosts);
+
+const scoredPosts = computeValueScores(allRoastPosts, inflationIndex).sort(
+  (a, b) => b.valueScore - a.valueScore
+);
+
+const pageTitle = "Best Value Roast Dinners in London";
+const description =
+  "Ranked by value score (rating divided by inflation-adjusted price): the cheap roast dinner London spots and best cheap Sunday roast London deals, including roast dinners under £15.";
+
+const valueListStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: pageTitle,
+  description,
+  itemListElement: scoredPosts.slice(0, 20).map(({ post }, idx) => ({
+    "@type": "ListItem",
+    position: idx + 1,
+    name: post.title,
+    url: post.slug && Astro.site ? new URL(post.slug, Astro.site).href : undefined,
+  })),
+};
+---
+
+<BaseLayout pageTitle={pageTitle} description={description} structuredData={valueListStructuredData}>
+  <FeaturedPostHeader imageSrc={logo3.src} title={pageTitle} />
+  <div class="container league-container">
+    <p>
+      Looking for a <strong>cheap roast dinner in London</strong> that doesn't skimp on quality? This
+      page ranks every venue we've reviewed by <strong>value score</strong> — rating divided by an
+      inflation-adjusted price, so a brilliant £14 roast visited in 2019 is fairly compared against a
+      brilliant £22 roast visited today. The best cheap Sunday roast London has to offer, and plenty of
+      roast dinners under £15, all in one place.
+    </p>
+    <p>
+      Filter by meat, area, borough or tube line to find the best value roast dinner near you, or just
+      scroll the ranked table below. Every price shown has been adjusted for roast dinner
+      inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""}, so you're comparing venues fairly
+      no matter when they were visited.
+    </p>
+
+    <div class="sort-posts-loading" id="best-value-loading">
+      <div class="loading-content">
+        <div class="loading-spinner"></div>
+        <p>Loading the value rankings...</p>
+      </div>
+    </div>
+
+    <div class="best-value-loading-container" style="opacity: 0; position: absolute; visibility: hidden;">
+      <BestValue client:only="react" posts={allRoastPosts} inflationIndex={inflationIndex} mostRecentYear={mostRecentYear} />
+    </div>
+
+    <script lang="ts">
+      document.addEventListener("DOMContentLoaded", () => {
+        let attempts = 0;
+        const maxAttempts = 20; // 2 seconds max
+
+        const checkForComponent = () => {
+          attempts++;
+          const bestValueElement = document.querySelector(".best-value-loading-container > div");
+          const loadingElement = document.getElementById("best-value-loading");
+          const containerElement = document.querySelector(".best-value-loading-container");
+
+          if (bestValueElement && loadingElement && containerElement) {
+            loadingElement.style.display = "none";
+            containerElement.style.position = "static";
+            containerElement.style.visibility = "visible";
+            containerElement.style.opacity = "1";
+            containerElement.style.transition = "opacity 0.2s ease-in-out";
+            return;
+          }
+
+          if (attempts < maxAttempts) {
+            setTimeout(checkForComponent, 100);
+          } else {
+            if (loadingElement) {
+              loadingElement.style.display = "none";
+            }
+            if (containerElement) {
+              containerElement.style.position = "static";
+              containerElement.style.visibility = "visible";
+              containerElement.style.opacity = "1";
+            }
+          }
+        };
+
+        checkForComponent();
+      });
+    </script>
+
+    <Newsletter />
+  </div>
+</BaseLayout>

--- a/src/pages/best-value-roast-dinners-london.astro
+++ b/src/pages/best-value-roast-dinners-london.astro
@@ -27,7 +27,8 @@ while (hasNextPage) {
     ...posts.nodes.filter(
       (post: Post) =>
         post.typesOfPost?.nodes.some((node: { name: string }) => node.name === "Roast Dinner") &&
-        !post.closedDowns?.nodes[0]?.name
+        !post.closedDowns?.nodes[0]?.name &&
+        post.areas?.nodes[0]?.name !== "Not Really London"
     )
   );
   hasNextPage = posts.pageInfo.hasNextPage;
@@ -69,8 +70,8 @@ const valueListStructuredData = {
       roast dinners under £15, all in one place.
     </p>
     <p>
-      Filter by meat, area, borough or tube line to find the best value roast dinner near you, or just
-      scroll the ranked table below. Every price shown has been adjusted for roast dinner
+      Filter by area, borough or tube line to find the best value roast dinner near you, or just scroll
+      the ranked table below. Every price shown has been adjusted for roast dinner
       inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""}, so you're comparing venues fairly
       no matter when they were visited.
     </p>

--- a/src/pages/best-value-roast-dinners-london.astro
+++ b/src/pages/best-value-roast-dinners-london.astro
@@ -26,7 +26,8 @@ while (hasNextPage) {
   allRoastPosts.push(
     ...posts.nodes.filter(
       (post: Post) =>
-        post.typesOfPost?.nodes.some((node: { name: string }) => node.name === "Roast Dinner") &&
+        post.typesOfPost?.nodes.length === 1 &&
+        post.typesOfPost.nodes[0]?.name === "Roast Dinner" &&
         !post.closedDowns?.nodes[0]?.name &&
         post.areas?.nodes[0]?.name !== "Not Really London"
     )
@@ -63,17 +64,15 @@ const valueListStructuredData = {
   <FeaturedPostHeader imageSrc={logo3.src} title={pageTitle} />
   <div class="container league-container">
     <p>
-      Looking for a <strong>cheap roast dinner in London</strong> that doesn't skimp on quality? This
-      page ranks every venue we've reviewed by <strong>value score</strong> — rating divided by an
-      inflation-adjusted price, so a brilliant £14 roast visited in 2019 is fairly compared against a
-      brilliant £22 roast visited today. The best cheap Sunday roast London has to offer, and plenty of
-      roast dinners under £15, all in one place.
+      A great roast dinner shouldn't have to cost a fortune. This page ranks every roast dinner I've
+      reviewed by value score — rating divided by an inflation-adjusted price — so a brilliant £14 roast
+      from 2019 gets compared fairly against a brilliant £22 roast today. If you're after a cheap roast
+      dinner in London that still hits the spot, or just fancy a roast dinner under £15, start here.
     </p>
     <p>
-      Filter by area, borough or tube line to find the best value roast dinner near you, or just scroll
-      the ranked table below. Every price shown has been adjusted for roast dinner
-      inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""}, so you're comparing venues fairly
-      no matter when they were visited.
+      Filter by area, borough or tube line to narrow it down, or just scroll the ranked table below. Every
+      price has been adjusted for roast dinner inflation{mostRecentYear ? ` to ${mostRecentYear} money` : ""},
+      so it doesn't matter when I visited — the comparison is fair.
     </p>
 
     <div class="sort-posts-loading" id="best-value-loading">

--- a/src/pages/best-value-roast-dinners-london.test.ts
+++ b/src/pages/best-value-roast-dinners-london.test.ts
@@ -53,6 +53,14 @@ describe("best-value-roast-dinners-london page", () => {
                   prices: { nodes: [{ name: "£1" }] },
                   closedDowns: { nodes: [] },
                 },
+                {
+                  title: "Combination Type Roast",
+                  slug: "combination-type-roast",
+                  typesOfPost: { nodes: [{ name: "Roast Dinner" }, { name: "Guide" }] },
+                  ratings: { nodes: [{ name: "10" }] },
+                  prices: { nodes: [{ name: "£1" }] },
+                  closedDowns: { nodes: [] },
+                },
               ],
               pageInfo: {
                 hasNextPage: true,
@@ -117,6 +125,7 @@ describe("best-value-roast-dinners-london page", () => {
     expect(html).not.toContain('"name":"Not A Roast"');
     expect(html).not.toContain('"name":"Closed Roast"');
     expect(html).not.toContain('"name":"Outside London"');
+    expect(html).not.toContain('"name":"Combination Type Roast"');
 
     const cheapIndex = html.indexOf('"name":"Cheap And Great"');
     const priceyIndex = html.indexOf('"name":"Pricey And Mediocre"');

--- a/src/pages/best-value-roast-dinners-london.test.ts
+++ b/src/pages/best-value-roast-dinners-london.test.ts
@@ -1,0 +1,115 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const fetchGraphQLMock = vi.fn();
+
+vi.mock("../lib/api", () => ({
+  fetchGraphQL: fetchGraphQLMock,
+}));
+
+vi.mock("../components/best-value/best-value.tsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) => `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  ),
+}));
+
+beforeEach(() => {
+  fetchGraphQLMock.mockReset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("best-value-roast-dinners-london page", () => {
+  test("fetches paginated posts, excludes closed/non-roast posts, and ranks structured data by value score", async () => {
+    fetchGraphQLMock.mockImplementation(
+      async (_query: string, variables: Record<string, unknown> = {}) => {
+        if (!variables.after) {
+          return {
+            posts: {
+              nodes: [
+                {
+                  title: "Cheap And Great",
+                  slug: "cheap-and-great",
+                  typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                  ratings: { nodes: [{ name: "9" }] },
+                  prices: { nodes: [{ name: "£12" }] },
+                  yearsOfVisit: { nodes: [{ name: "2024" }] },
+                  closedDowns: { nodes: [] },
+                },
+                {
+                  title: "Not A Roast",
+                  slug: "not-a-roast",
+                  typesOfPost: { nodes: [{ name: "Guide" }] },
+                  ratings: { nodes: [{ name: "10" }] },
+                  prices: { nodes: [{ name: "£1" }] },
+                  closedDowns: { nodes: [] },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "cursor-1",
+              },
+            },
+          };
+        }
+
+        return {
+          posts: {
+            nodes: [
+              {
+                title: "Closed Roast",
+                slug: "closed-roast",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                ratings: { nodes: [{ name: "10" }] },
+                prices: { nodes: [{ name: "£5" }] },
+                closedDowns: { nodes: [{ name: "closeddown" }] },
+              },
+              {
+                title: "Pricey And Mediocre",
+                slug: "pricey-and-mediocre",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                ratings: { nodes: [{ name: "6" }] },
+                prices: { nodes: [{ name: "£30" }] },
+                yearsOfVisit: { nodes: [{ name: "2024" }] },
+                closedDowns: { nodes: [] },
+              },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+            },
+          },
+        };
+      }
+    );
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./best-value-roast-dinners-london.astro");
+    const html = await container.renderToString(Page);
+
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(2);
+    expect(fetchGraphQLMock).toHaveBeenNthCalledWith(1, expect.anything(), {});
+    expect(fetchGraphQLMock).toHaveBeenNthCalledWith(2, expect.anything(), { after: "cursor-1" });
+
+    expect(html).toContain("Best Value Roast Dinners in London");
+    expect(html).toContain("cheap roast dinner");
+
+    expect(html).toContain('"@type":"ItemList"');
+    expect(html).not.toContain('"name":"Not A Roast"');
+    expect(html).not.toContain('"name":"Closed Roast"');
+
+    const cheapIndex = html.indexOf('"name":"Cheap And Great"');
+    const priceyIndex = html.indexOf('"name":"Pricey And Mediocre"');
+    expect(cheapIndex).toBeGreaterThan(-1);
+    expect(priceyIndex).toBeGreaterThan(-1);
+    expect(cheapIndex).toBeLessThan(priceyIndex);
+  });
+});

--- a/src/pages/best-value-roast-dinners-london.test.ts
+++ b/src/pages/best-value-roast-dinners-london.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe("best-value-roast-dinners-london page", () => {
-  test("fetches paginated posts, excludes closed/non-roast posts, and ranks structured data by value score", async () => {
+  test("fetches paginated posts, excludes closed/non-roast/not-really-london posts, and ranks structured data by value score", async () => {
     fetchGraphQLMock.mockImplementation(
       async (_query: string, variables: Record<string, unknown> = {}) => {
         if (!variables.after) {
@@ -42,6 +42,7 @@ describe("best-value-roast-dinners-london page", () => {
                   ratings: { nodes: [{ name: "9" }] },
                   prices: { nodes: [{ name: "£12" }] },
                   yearsOfVisit: { nodes: [{ name: "2024" }] },
+                  areas: { nodes: [{ name: "Soho" }] },
                   closedDowns: { nodes: [] },
                 },
                 {
@@ -73,12 +74,22 @@ describe("best-value-roast-dinners-london page", () => {
                 closedDowns: { nodes: [{ name: "closeddown" }] },
               },
               {
+                title: "Outside London",
+                slug: "outside-london",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                ratings: { nodes: [{ name: "10" }] },
+                prices: { nodes: [{ name: "£5" }] },
+                areas: { nodes: [{ name: "Not Really London" }] },
+                closedDowns: { nodes: [] },
+              },
+              {
                 title: "Pricey And Mediocre",
                 slug: "pricey-and-mediocre",
                 typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
                 ratings: { nodes: [{ name: "6" }] },
                 prices: { nodes: [{ name: "£30" }] },
                 yearsOfVisit: { nodes: [{ name: "2024" }] },
+                areas: { nodes: [{ name: "Camden" }] },
                 closedDowns: { nodes: [] },
               },
             ],
@@ -105,6 +116,7 @@ describe("best-value-roast-dinners-london page", () => {
     expect(html).toContain('"@type":"ItemList"');
     expect(html).not.toContain('"name":"Not A Roast"');
     expect(html).not.toContain('"name":"Closed Roast"');
+    expect(html).not.toContain('"name":"Outside London"');
 
     const cheapIndex = html.indexOf('"name":"Cheap And Great"');
     const priceyIndex = html.indexOf('"name":"Pricey And Mediocre"');

--- a/src/styles/best-value.css
+++ b/src/styles/best-value.css
@@ -1,0 +1,118 @@
+.best-value-container {
+  p {
+    margin: 0;
+  }
+
+  button {
+    margin: 0;
+  }
+
+  .share-button {
+    margin-left: 1rem;
+  }
+
+  .filter-posts {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+    gap: 1rem;
+
+    @media (min-width: 768px) {
+      flex-direction: row;
+      gap: 2rem;
+    }
+
+    div {
+      display: flex;
+      flex-direction: column;
+
+      @media (min-width: 768px) {
+        max-width: 300px;
+      }
+    }
+
+    select,
+    option {
+      margin-top: 0.5rem;
+    }
+  }
+
+  .sort-posts {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 1rem;
+  }
+
+  .clear-button,
+  .share-button {
+    margin-top: 1rem;
+  }
+
+  .value-score-note {
+    margin-top: 1.5rem;
+    font-style: italic;
+    color: var(--text-muted, var(--roast-main-text));
+  }
+
+  .value-scatter {
+    margin-top: 1rem;
+    max-width: 640px;
+
+    svg {
+      width: 100%;
+      height: auto;
+    }
+
+    .axis-line {
+      stroke: var(--roast-main-text);
+      stroke-width: 1;
+    }
+
+    .axis-label {
+      font-size: 8px;
+      fill: var(--text-muted, var(--roast-main-text));
+    }
+
+    .value-dot {
+      fill: var(--roast-new-blue, #1d4ed8);
+      fill-opacity: 0.75;
+      stroke: var(--roast-main-text);
+      stroke-width: 0.5;
+    }
+
+    a:focus-visible .value-dot {
+      stroke: var(--blood);
+      stroke-width: 1.5;
+    }
+  }
+
+  .value-table {
+    margin-top: 1.5rem;
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--roast-main-text);
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.5rem;
+      border-bottom: 1px solid var(--border-color, #ccc);
+    }
+
+    th {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    a {
+      text-decoration: underline;
+      color: var(--roast-main-text);
+    }
+  }
+}

--- a/src/styles/best-value.css
+++ b/src/styles/best-value.css
@@ -67,6 +67,9 @@
     td {
       text-align: left;
       padding: 0.5rem;
+    }
+
+    thead th {
       border-bottom: 1px solid var(--border-color, #ccc);
     }
 

--- a/src/styles/best-value.css
+++ b/src/styles/best-value.css
@@ -38,16 +38,6 @@
     }
   }
 
-  .sort-posts {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 1rem;
-    align-items: center;
-    justify-content: flex-start;
-    margin-bottom: 1rem;
-  }
-
   .clear-button,
   .share-button {
     margin-top: 1rem;
@@ -57,38 +47,6 @@
     margin-top: 1.5rem;
     font-style: italic;
     color: var(--text-muted, var(--roast-main-text));
-  }
-
-  .value-scatter {
-    margin-top: 1rem;
-    max-width: 640px;
-
-    svg {
-      width: 100%;
-      height: auto;
-    }
-
-    .axis-line {
-      stroke: var(--roast-main-text);
-      stroke-width: 1;
-    }
-
-    .axis-label {
-      font-size: 8px;
-      fill: var(--text-muted, var(--roast-main-text));
-    }
-
-    .value-dot {
-      fill: var(--roast-new-blue, #1d4ed8);
-      fill-opacity: 0.75;
-      stroke: var(--roast-main-text);
-      stroke-width: 0.5;
-    }
-
-    a:focus-visible .value-dot {
-      stroke: var(--blood);
-      stroke-width: 1.5;
-    }
   }
 
   .value-table {

--- a/src/styles/best-value.css
+++ b/src/styles/best-value.css
@@ -11,6 +11,10 @@
     margin-left: 1rem;
   }
 
+  .show-hide-button {
+    margin: 1rem 0;
+  }
+
   .filter-posts {
     display: flex;
     flex-direction: column;
@@ -30,6 +34,10 @@
       @media (min-width: 768px) {
         max-width: 300px;
       }
+    }
+
+    label {
+      margin-top: 1rem;
     }
 
     select,


### PR DESCRIPTION
Closes #449.

## Summary
- New page `/best-value-roast-dinners-london` ranking every open roast dinner review by **value score** (rating ÷ inflation-adjusted price), reusing the existing `computeInflationIndex` logic (`src/lib/inflationIndex.ts`) so venues visited in different years are compared fairly.
- New `src/lib/valueScore.ts` computes the raw/adjusted price and value score per post.
- New `BestValue` React island (`src/components/best-value/`) with filters for meat, area, borough and tube line, a sortable ranked table, and a shareable-link/URL-param pattern mirroring `sort-posts`.
- A dependency-free SVG scatter plot (price vs rating) as suggested in the issue, avoiding a new charting library.
- SEO-oriented intro copy targeting "cheap roast dinner London" / "best cheap Sunday roast London" style queries, plus `ItemList` structured data.
- Added a nav link ("Best Value Roasts") in the header, and the URL matches the sitemap's existing `/best-` priority-boost rule so no sitemap config change was needed.

## Test plan
- [x] `yarn vitest run` — full suite passes (390/390)
- [x] `yarn astro check` — no new errors/warnings
- [x] `yarn biome check` — clean
- [ ] Manual check of the live page in a browser (not run in this environment — WP GraphQL backend not reachable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
