### PR TITLE
Cover borough and tube-line filter branches in BestValue component

### DIFF
--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -169,4 +169,116 @@ describe("best-value component", () => {
       root.unmount();
     });
   });
+
+  test("filters by borough and clears filters", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    const showOptionsButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show all options / filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      showOptionsButton.click();
+    });
+    await waitForRender();
+
+    const boroughFilter = host.querySelector('select[name="borough"]') as HTMLSelectElement;
+    await act(async () => {
+      boroughFilter.value = "Westminster";
+      boroughFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great"]);
+
+    const clearButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Clear All Filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      clearButton.click();
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great", "Pricey And Mediocre"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("filters by tube line and matches multi-line posts on any of their lines", async () => {
+    const multiLinePosts: Post[] = [
+      {
+        date: "2026-01-01",
+        title: "Two Lines",
+        slug: "two-lines",
+        ratings: { nodes: [{ name: "8" }] },
+        prices: { nodes: [{ name: "£12" }] },
+        tubeLines: { nodes: [{ name: "Central" }, { name: "Northern" }] },
+      },
+      {
+        date: "2026-01-01",
+        title: "Central Only",
+        slug: "central-only",
+        ratings: { nodes: [{ name: "7" }] },
+        prices: { nodes: [{ name: "£14" }] },
+        tubeLines: { nodes: [{ name: "Central" }] },
+      },
+      {
+        date: "2026-01-01",
+        title: "Victoria Only",
+        slug: "victoria-only",
+        ratings: { nodes: [{ name: "9" }] },
+        prices: { nodes: [{ name: "£15" }] },
+        tubeLines: { nodes: [{ name: "Victoria" }] },
+      },
+    ];
+
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={multiLinePosts} />);
+    });
+    await waitForRender();
+
+    const showOptionsButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show all options / filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      showOptionsButton.click();
+    });
+    await waitForRender();
+
+    const tubeLineFilter = host.querySelector('select[name="tubeLine"]') as HTMLSelectElement;
+
+    await act(async () => {
+      tubeLineFilter.value = "Northern";
+      tubeLineFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Two Lines"]);
+
+    await act(async () => {
+      tubeLineFilter.value = "Central";
+      tubeLineFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    const centralResults = getVenueNames(host);
+    expect(centralResults).toContain("Two Lines");
+    expect(centralResults).toContain("Central Only");
+    expect(centralResults).not.toContain("Victoria Only");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## What

Two new tests added to `src/components/best-value/best-value.test.tsx`, covering filter branches that had no coverage:

1. **Borough filter** — exercises the `filters.borough ? borough === filters.borough : true` branch in `useValueFilter`'s `filterScoredPosts`, including clearing the filter and restoring all results.

2. **Tube line filter with multi-line posts** — exercises the `filters.tubeLine ? tubeLines.includes(filters.tubeLine) : true` branch. Critically, this uses `includes()` over an array of tube lines, which is semantically different from the simple equality checks used for area/borough. The test uses a post assigned to two tube lines and verifies it appears under *either* line — a regression test for the case where `includes()` is accidentally replaced with `===`.

## Test count

- Before: 390 tests across 109 files  
- After: 392 tests across 109 files (same files, two new tests added)

## What bug it would catch

If `filterScoredPosts` were changed to use `=== filters.tubeLine` instead of `.includes(filters.tubeLine)`, the multi-line post test would fail immediately. The borough test guards against the filter branch being silently short-circuited or removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvAQCKcgM3LL1gdFxWjcpP)_