### PR TITLE
fix(types): add missing return type annotations

### DIFF
--- a/src/components/comment/comment.astro
+++ b/src/components/comment/comment.astro
@@ -35,7 +35,7 @@ const formatDate = (dateString: string): string => {
   const formattedDate = date.toLocaleDateString("en-US", options);
 
   const day = date.getDate();
-  const ordinalSuffix = (day: number) => {
+  const ordinalSuffix = (day: number): string => {
     if (day > 3 && day < 21) return "th";
     switch (day % 10) {
       case 1:

--- a/src/components/dropdown/dropdown.astro
+++ b/src/components/dropdown/dropdown.astro
@@ -32,7 +32,7 @@ const {
   center = false,
 } = Astro.props;
 
-const getDisplayLabel = (labelToFormat: string) => {
+const getDisplayLabel = (labelToFormat: string): string => {
   if (!maxOptionLabelLength || labelToFormat.length <= maxOptionLabelLength) {
     return labelToFormat;
   }

--- a/src/components/sunday-roast-planner/sunday-roast-planner.tsx
+++ b/src/components/sunday-roast-planner/sunday-roast-planner.tsx
@@ -167,12 +167,12 @@ const SundayRoastPlanner = ({
     window.history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
   }, []);
 
-  function showResults() {
+  function showResults(): void {
     updateUrl(locationType, area, borough, tubeLine, budget, minRating);
     setStep("results");
   }
 
-  function reset() {
+  function reset(): void {
     setLocationType("area");
     setArea("");
     setBorough("");
@@ -183,14 +183,14 @@ const SundayRoastPlanner = ({
     window.history.replaceState(null, "", window.location.pathname);
   }
 
-  function copyLink() {
+  function copyLink(): void {
     navigator.clipboard.writeText(window.location.href).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
   }
 
-  function handleSaveToggle(slug: string, nowSaved: boolean) {
+  function handleSaveToggle(slug: string, nowSaved: boolean): void {
     setSavedSlugs((prev) => {
       const next = new Set(prev);
       if (nowSaved) next.add(slug);
@@ -199,7 +199,7 @@ const SundayRoastPlanner = ({
     });
   }
 
-  function switchLocationType(lt: LocationType) {
+  function switchLocationType(lt: LocationType): void {
     setLocationType(lt);
     setArea("");
     setBorough("");

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -110,7 +110,7 @@ const CLOSED_STATUS_LABELS: Record<string, string> = {
 
 const closedDownId = post.closedDowns?.nodes?.[0]?.name;
 
-const getClosedMessage = () => {
+const getClosedMessage = (): string => {
   if (!closedDownId) return "";
 
   if (closedDownId.includes("re-reviewed")) {

--- a/src/pages/best-roast-dinner-in-south-west-london.astro
+++ b/src/pages/best-roast-dinner-in-south-west-london.astro
@@ -11,8 +11,8 @@ import type { Post } from "../types";
 const pageId = "5612";
 const singlePage = await fetchPageData(pageId);
 
-const getSouthWestTopRatedRoasts = async () => {
-  const allPosts = [];
+const getSouthWestTopRatedRoasts = async (): Promise<{ topRated: Post[]; highRated: Post[] }> => {
+  const allPosts: Post[] = [];
   let hasNextPage = true;
   let endCursor: string | null = null;
 

--- a/src/pages/which-fare-zones-do-i-visit-most-often.astro
+++ b/src/pages/which-fare-zones-do-i-visit-most-often.astro
@@ -20,7 +20,7 @@ const singlePage = await getSinglePageData({ variables });
 const zoneCountsByYear = new Map<string, Record<string, number>>();
 const totalZoneCounts: Record<string, number> = {};
 
-const getZoneNumber = (zoneName: string) => {
+const getZoneNumber = (zoneName: string): number => {
   const match = zoneName.match(/\d+/);
   return match ? Number.parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
 };
@@ -57,7 +57,7 @@ while (hasNextPage) {
   endCursor = posts.pageInfo.endCursor;
 }
 
-const sortZones = (a: [string, number], b: [string, number]) => {
+const sortZones = (a: [string, number], b: [string, number]): number => {
   const aNum = getZoneNumber(a[0]);
   const bNum = getZoneNumber(b[0]);
   if (aNum !== bNum) return aNum - bNum;


### PR DESCRIPTION
## Summary

- **`best-roast-dinner-in-south-west-london.astro`**: Fix `allPosts` inferred as `never[]` in strict mode — annotated as `Post[]`, and add an explicit `Promise<{ topRated: Post[]; highRated: Post[] }>` return type to `getSouthWestTopRatedRoasts`
- **`sunday-roast-planner.tsx`**: Add `: void` return type to five internal helper functions (`showResults`, `reset`, `copyLink`, `handleSaveToggle`, `switchLocationType`)
- **`dropdown.astro`**: Add `: string` return type to `getDisplayLabel`
- **`comment.astro`**: Add `: string` return type to `ordinalSuffix`
- **`[slug].astro`**: Add `: string` return type to `getClosedMessage`
- **`which-fare-zones-do-i-visit-most-often.astro`**: Add `: number` return type to `getZoneNumber` and `sortZones`

## Why

The codebase uses `strict: true` and `noImplicitAny: true`. The `const allPosts = []` in the south-west London page would be inferred as `never[]` by the compiler, making subsequent `push(...Post[])` calls a type error. All other changes add explicit return types that TypeScript was previously inferring — making signatures self-documenting and ensuring future changes to function bodies that alter the return type are caught at the declaration rather than the call site.

No logic was changed; these are annotation-only fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Aq8FNcKcUq5ykpWf1mPdv)_