### PR TITLE
Cover all CLOSED_STATUS_LABELS branches in [slug].astro

### DIFF
--- a/src/pages/slug.test.ts
+++ b/src/pages/slug.test.ts
@@ -413,4 +413,57 @@ describe("[slug] render", () => {
       expect(result).toBe("");
     }
   });
+
+  test.each([
+    ["closeddown", "Closed Down"],
+    ["tempclosed", "Temporarily Closed"],
+    ["newmanagement", "Under New Management"],
+    ["popupmoved", "Popup Now Trading Elsewhere"],
+    ["popupstopped", "Popup Stopped Trading"],
+    ["unknown-status", "Closed Down"],
+  ])('renders closed status label for closedDownId "%s"', async (closedDownId, expectedLabel) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-27T00:00:00.000Z"));
+
+    const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.query.includes("GetAllPosts")) {
+        return makeResponse({ posts: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } });
+      }
+      return makeResponse({
+        post: {
+          postId: "200",
+          date: "2025-06-01",
+          content: "<p>Review</p>",
+          title: "Status Venue",
+          featuredImage: { node: { sourceUrl: "https://example.com/img.jpg" } },
+          seo: { opengraphDescription: "Desc", opengraphImage: { sourceUrl: "https://example.com/og.jpg" } },
+          areas: { nodes: [{ name: "East" }] },
+          boroughs: { nodes: [{ name: "Hackney" }] },
+          tubeStations: { nodes: [{ name: "Bethnal Green" }] },
+          tubeLines: { nodes: [{ name: "Central" }] },
+          prices: { nodes: [{ name: "£20" }] },
+          ratings: { nodes: [{ name: "7" }] },
+          yearsOfVisit: { nodes: [{ name: "2025" }] },
+          typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+          closedDowns: { nodes: [{ name: closedDownId }] },
+          nSFWs: { nodes: [] },
+          highlights: { loved: "Gravy", loathed: "Nothing" },
+          comments: { nodes: [] }
+        }
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[slug].astro");
+    const html = await container.renderToString(Page, {
+      params: { slug: "status-venue" },
+      props: { contentType: "post" },
+      request: new Request("https://rdldn.co.uk/status-venue")
+    });
+
+    expect(html).toContain(expectedLabel);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds 6 tests (via `test.each`) to `src/pages/slug.test.ts` covering the previously untested branches of `getClosedMessage()` in `[slug].astro`
- The five named entries in `CLOSED_STATUS_LABELS` (`closeddown`, `tempclosed`, `newmanagement`, `popupmoved`, `popupstopped`) were all untested
- The `?? "Closed Down"` fallback for unknown closed-status codes was also untested

## Why this matters

The slug page uses **different label strings** from the equivalent `translateClosedDown` function in `sort-posts` — for example, `"Popup Now Trading Elsewhere"` vs `"Popup Moved"` and `"Under New Owners"` vs `"New Owners"`. A regression in the slug page's labels would not be caught by the sort-posts tests, and the wrong message would silently appear on every closed venue's page. These tests lock in the correct strings and cover the unknown-status fallback path.

## Test count

- Before: 392 tests across 109 files
- After: 398 tests across 109 files (+6)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPoMpSwSfkiha7RXjnJ35M)_