### PR TITLE
perf: defer auth island hydration from client:load to client:idle

### DIFF
--- a/src/components/header/HeaderAuth.tsx
+++ b/src/components/header/HeaderAuth.tsx
@@ -1,15 +1,6 @@
 import { Show, SignInButton, UserButton } from "@clerk/astro/react";
-import { memo, useEffect, useState } from "react";
-
-function useAuthFlag(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-  useEffect(() => {
-    const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
-    const val = match ? match[2] : null;
-    setEnabled(val === null ? false : val === "true");
-  }, []);
-  return enabled;
-}
+import { memo } from "react";
+import { useAuthFlag } from "../../hooks/useAuthFlag";
 
 export const HeaderAuthDesktop = memo(function HeaderAuthDesktop() {
   const enabled = useAuthFlag();

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -20,7 +20,7 @@ const isTesting = import.meta.env.PLAYWRIGHT === "true";
       </div>
 
       <div class="header-top-right">
-        {!isTesting && <HeaderAuthDesktop client:load />}
+        {!isTesting && <HeaderAuthDesktop client:idle />}
         <button
           id="theme-toggle"
           class="theme-toggle"
@@ -60,7 +60,7 @@ const isTesting = import.meta.env.PLAYWRIGHT === "true";
       <a href="/to-do-list">To-Do List</a>
       <a href="/search">Search</a>
       <a href="/archive">Archive</a>
-      {!isTesting && <HeaderAuthMobile client:load />}
+      {!isTesting && <HeaderAuthMobile client:idle />}
       <div class="dropdown">
         <a
           href="/about"

--- a/src/components/my-roast-list-item/MyRoastListItem.tsx
+++ b/src/components/my-roast-list-item/MyRoastListItem.tsx
@@ -1,14 +1,5 @@
-import { memo, useEffect, useState } from "react";
-
-function useAuthFlag(): boolean | null {
-  const [enabled, setEnabled] = useState<boolean | null>(null);
-  useEffect(() => {
-    const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
-    const val = match ? match[2] : null;
-    setEnabled(val === null ? false : val === "true");
-  }, []);
-  return enabled;
-}
+import { memo } from "react";
+import { useAuthFlag } from "../../hooks/useAuthFlag";
 
 type MyRoastListItemProps = {
   imgSrc: string;

--- a/src/hooks/useAuthFlag.ts
+++ b/src/hooks/useAuthFlag.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export function useAuthFlag(): boolean | null {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
+    const val = match ? match[2] : null;
+    setEnabled(val === null ? false : val === "true");
+  }, []);
+  return enabled;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -330,7 +330,7 @@ try {
           <img src={findARoastImg.src} alt="Find a roast" width="400" height="300" loading="lazy" />
         </a>
       </li>
-      <MyRoastListItem imgSrc={dreamingOfRoastDinners.src} client:load />
+      <MyRoastListItem imgSrc={dreamingOfRoastDinners.src} client:idle />
       <li class="heading">
         <h3><a href="/guessthescore" rel="noopener noreferrer">Guess The Score</a></h3>
         <a href="/guessthescore" rel="noopener noreferrer" class="featured-image">


### PR DESCRIPTION
## Summary

- `HeaderAuthDesktop` and `HeaderAuthMobile` changed from `client:load` to `client:idle` in `header.astro`
- `MyRoastListItem` changed from `client:load` to `client:idle` in `index.astro`
- Extracted duplicated `useAuthFlag` hook from both components into `src/hooks/useAuthFlag.ts`

## Why

All three components read the `flag_authFeatures` cookie inside a `useEffect`, which means they render `null` on their first pass regardless of the hydration strategy. There is no visible difference between `client:load` and `client:idle` for these components — the auth UI cannot appear until after the effect fires in either case.

Switching to `client:idle` defers the Clerk React SDK from the critical rendering path to after the browser finishes layout. Since `header.astro` is included on every page, this reduces main-thread pressure on every page load without any change in perceived behaviour for users.

The `useAuthFlag` extraction removes ~10 lines of duplicated logic. If the cookie name or parsing logic ever changes, there is now one place to update it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoDqonSKqSPpHZmUK28u77)_