### PR TITLE
feat: add personal visit log for Roast Dinner Passport

### DIFF
--- a/drizzle/0002_abandoned_ronan.sql
+++ b/drizzle/0002_abandoned_ronan.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "visits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"post_slug" text NOT NULL,
+	"post_title" text NOT NULL,
+	"post_rating" numeric,
+	"visited_at" timestamp DEFAULT now() NOT NULL,
+	"notes" text,
+	CONSTRAINT "visits_user_id_post_slug_unique" UNIQUE("user_id","post_slug")
+);
+--> statement-breakpoint
+ALTER TABLE "visits" ADD CONSTRAINT "visits_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,288 @@
+{
+  "id": "4706d225-910a-4a1c-a8ea-5f17a69d613a",
+  "prevId": "0fce8c38-4963-47a8-b72c-7522940df36d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.game_personal_bests": {
+      "name": "game_personal_bests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game": {
+          "name": "game",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_personal_bests_user_id_users_id_fk": {
+          "name": "game_personal_bests_user_id_users_id_fk",
+          "tableFrom": "game_personal_bests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_personal_bests_user_id_game_unique": {
+          "name": "game_personal_bests_user_id_game_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visits": {
+      "name": "visits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_rating": {
+          "name": "post_rating",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visited_at": {
+          "name": "visited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visits_user_id_users_id_fk": {
+          "name": "visits_user_id_users_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visits_user_id_post_slug_unique": {
+          "name": "visits_user_id_post_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlist_items": {
+      "name": "wishlist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_slug": {
+          "name": "post_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_rating": {
+          "name": "post_rating",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wishlist_items_user_id_users_id_fk": {
+          "name": "wishlist_items_user_id_users_id_fk",
+          "tableFrom": "wishlist_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wishlist_items_user_id_post_slug_unique": {
+          "name": "wishlist_items_user_id_post_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "post_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778131682791,
       "tag": "0001_round_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783539927075,
+      "tag": "0002_abandoned_ronan",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/visit-button/visit-button.astro
+++ b/src/components/visit-button/visit-button.astro
@@ -1,0 +1,37 @@
+---
+type Props = {
+  postSlug: string;
+  postTitle: string;
+  postRating?: string | null;
+};
+
+const { postSlug, postTitle, postRating } = Astro.props;
+
+import "./visit-button.css";
+---
+
+<div
+  x-data={`visitButton(${JSON.stringify({ postSlug, postTitle, postRating: postRating ?? null })})`}
+>
+  <a x-show="signedOut" href="/sign-in" class="visit-btn visit-sign-in"
+    >Sign in to log a visit</a
+  >
+  <button
+    x-show="!signedOut"
+    type="button"
+    x-on:click="toggle()"
+    x-bind:disabled="loading"
+    x-bind:class="visited ? 'visit-btn visit-btn--visited' : 'visit-btn'"
+    x-bind:aria-label="visited ? 'Remove visit' : 'Mark as visited'"
+    x-bind:aria-pressed="visited"
+  >
+    <span aria-hidden="true" style="line-height:1;display:inline-block;width:1em;text-align:center">
+      <span x-show="loading">…</span>
+      <svg x-show="!loading && visited" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" fill="currentColor"><path d="M173.9 439.4L7 273.1c-9.4-9.4-9.4-24.6 0-33.9l39.6-39.6c9.4-9.4 24.6-9.4 33.9 0L192 311.1 433.5 69.6c9.4-9.4 24.6-9.4 33.9 0l39.6 39.6c9.4 9.4 9.4 24.6 0 33.9l-299 299.9c-9.4 9.5-24.6 9.5-34.1.4z"/></svg>
+      <svg x-show="!loading && !visited" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="32"><circle cx="256" cy="256" r="224"/></svg>
+    </span>
+    <span
+      x-text="loading ? 'Saving…' : visited ? ' Visited' : ' Mark as visited'"
+    ></span>
+  </button>
+</div>

--- a/src/components/visit-button/visit-button.css
+++ b/src/components/visit-button/visit-button.css
@@ -1,0 +1,28 @@
+.visit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: 2px solid var(--roast-new-blue);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  color: var(--roast-main-text);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: normal;
+  text-transform: none;
+  height: auto;
+  margin: 10px 0;
+  min-width: 13rem;
+  text-decoration: none;
+  justify-content: center;
+}
+
+.visit-btn--visited {
+  border-color: var(--roast-pink);
+}
+
+.visit-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -7,6 +7,12 @@ type WishlistButtonProps = {
   postRating: string | null;
 };
 
+type VisitButtonProps = {
+  postSlug: string;
+  postTitle: string;
+  postRating: string | null;
+};
+
 export default (alpine: AlpineInstance) => {
   (window as unknown as { Alpine: AlpineInstance }).Alpine = alpine;
 
@@ -57,6 +63,61 @@ export default (alpine: AlpineInstance) => {
               body: JSON.stringify({ postSlug, postTitle, postRating }),
             });
             if (res.ok) this.saved = true;
+          }
+        } finally {
+          this.loading = false;
+        }
+      },
+    };
+  });
+
+  alpine.data("visitButton", (props: VisitButtonProps = {} as VisitButtonProps) => {
+    const { postSlug, postTitle, postRating } = props;
+    return {
+      visited: false,
+      signedOut: false,
+      loading: false,
+
+      async init() {
+        const clerk = (window as unknown as { Clerk?: ClerkInstance }).Clerk;
+        if (!clerk) {
+          this.signedOut = true;
+          return;
+        }
+        // Wait for Clerk to finish loading if it hasn't yet
+        if (!clerk.loaded) {
+          await new Promise<void>((resolve) => clerk.addListener(() => resolve()));
+        }
+        if (!clerk.user) {
+          this.signedOut = true;
+          return;
+        }
+        // Check if this post is already logged as visited
+        try {
+          const res = await fetch("/api/visits");
+          if (res.ok) {
+            const items: { postSlug: string }[] = await res.json();
+            this.visited = items.some((item) => item.postSlug === postSlug);
+          }
+        } catch {
+          // ignore — visited stays false
+        }
+      },
+
+      async toggle() {
+        if (this.loading) return;
+        this.loading = true;
+        try {
+          if (this.visited) {
+            const res = await fetch(`/api/visits/${postSlug}`, { method: "DELETE" });
+            if (res.ok) this.visited = false;
+          } else {
+            const res = await fetch("/api/visits", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ postSlug, postTitle, postRating }),
+            });
+            if (res.ok) this.visited = true;
           }
         } finally {
           this.loading = false;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -22,6 +22,22 @@ export const wishlistItems = pgTable(
   (table) => [unique().on(table.userId, table.postSlug)]
 );
 
+export const visits = pgTable(
+  "visits",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    postSlug: text("post_slug").notNull(),
+    postTitle: text("post_title").notNull(),
+    postRating: numeric("post_rating"),
+    visitedAt: timestamp("visited_at").defaultNow().notNull(),
+    notes: text("notes"),
+  },
+  (table) => [unique().on(table.userId, table.postSlug)]
+);
+
 export const gamePersonalBests = pgTable(
   "game_personal_bests",
   {
@@ -38,4 +54,5 @@ export const gamePersonalBests = pgTable(
 
 export type User = typeof users.$inferSelect;
 export type WishlistItem = typeof wishlistItems.$inferSelect;
+export type Visit = typeof visits.$inferSelect;
 export type GamePersonalBest = typeof gamePersonalBests.$inferSelect;

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -20,6 +20,7 @@ import FeaturedPostHeader from "../components/featured-post-header/featured-post
 import Newsletter from "../components/newsletter/newsletter.astro";
 import RoastByTagSection from "../components/roastByTagSection/roast-by-tag-section.astro";
 import ShareReviewButton from "../components/share-review-button/share-review-button.astro";
+import VisitButton from "../components/visit-button/visit-button.astro";
 import WishlistButton from "../components/wishlist-button/wishlist-button.astro";
 import logo3 from "../images/logo-3.png";
 import { buildInflationIndex } from "../lib/inflationIndex";
@@ -331,6 +332,11 @@ const reviewStructuredData =
       )}
     </section>
     <WishlistButton
+      postSlug={String(slug)}
+      postTitle={singlePost.title ?? ""}
+      postRating={rating ?? null}
+    />
+    <VisitButton
       postSlug={String(slug)}
       postTitle={singlePost.title ?? ""}
       postRating={rating ?? null}

--- a/src/pages/api/visits.test.ts
+++ b/src/pages/api/visits.test.ts
@@ -1,0 +1,100 @@
+import type { APIContext } from "astro";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../lib/db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+import { db } from "../../lib/db";
+import { GET, POST } from "./visits";
+
+function makeContext(clerkId: string | null, body?: unknown): APIContext {
+  return {
+    locals: { auth: () => ({ userId: clerkId }) },
+    request: { json: () => Promise.resolve(body) },
+  } as unknown as APIContext;
+}
+
+function makeSelectChain(result: unknown[] = []) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+    orderBy: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("GET /api/visits", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("returns 401 when unauthenticated", async () => {
+    const response = await GET(makeContext(null));
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Unauthorized");
+  });
+
+  test("returns an empty list when user is not in the database", async () => {
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([]) as never);
+    const response = await GET(makeContext("clerk_abc"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
+  });
+
+  test("returns the user's visits", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-uuid" }]) as never)
+      .mockReturnValueOnce(makeSelectChain([{ postSlug: "some-post-slug" }]) as never);
+
+    const response = await GET(makeContext("clerk_abc"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ postSlug: "some-post-slug" }]);
+  });
+});
+
+describe("POST /api/visits", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("returns 401 when unauthenticated", async () => {
+    const response = await POST(makeContext(null, { postSlug: "a", postTitle: "A" }));
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Unauthorized");
+  });
+
+  test("returns 400 when postSlug or postTitle is missing", async () => {
+    const response = await POST(makeContext("clerk_abc", { postSlug: "a" }));
+    expect(response.status).toBe(400);
+  });
+
+  test("creates a new user and logs the visit and returns 201", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([]) as never)
+      .mockReturnValueOnce(makeSelectChain([]) as never);
+    vi.mocked(db.insert)
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "new-user-uuid" }]),
+        }),
+      } as never)
+      .mockReturnValueOnce({
+        values: vi.fn().mockResolvedValue(undefined),
+      } as never);
+
+    const response = await POST(makeContext("clerk_abc", { postSlug: "some-post-slug", postTitle: "Some Post" }));
+    expect(response.status).toBe(201);
+    expect((await response.json()).visited).toBe(true);
+  });
+
+  test("returns 200 without inserting when the visit already exists", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-uuid" }]) as never)
+      .mockReturnValueOnce(makeSelectChain([{ id: "visit-uuid" }]) as never);
+
+    const response = await POST(makeContext("clerk_abc", { postSlug: "some-post-slug", postTitle: "Some Post" }));
+    expect(response.status).toBe(200);
+    expect((await response.json()).visited).toBe(true);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -1,0 +1,79 @@
+import type { APIContext } from "astro";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../lib/db";
+import { users, visits } from "../../lib/schema";
+
+async function getUserId(clerkId: string): Promise<string | null> {
+  const [user] = await db.select({ id: users.id }).from(users).where(eq(users.clerkId, clerkId)).limit(1);
+  return user?.id ?? null;
+}
+
+export async function GET(context: APIContext) {
+  const { userId: clerkId } = context.locals.auth();
+
+  if (!clerkId) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const userId = await getUserId(clerkId);
+  if (!userId) {
+    return new Response(JSON.stringify([]), { headers: { "Content-Type": "application/json" } });
+  }
+
+  const items = await db.select().from(visits).where(eq(visits.userId, userId)).orderBy(visits.visitedAt);
+
+  return new Response(JSON.stringify(items), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(context: APIContext) {
+  const { userId: clerkId } = context.locals.auth();
+
+  if (!clerkId) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const body = await context.request.json();
+  const { postSlug, postTitle, postRating, notes } = body as {
+    postSlug: string;
+    postTitle: string;
+    postRating?: string | null;
+    notes?: string | null;
+  };
+
+  if (!postSlug || !postTitle) {
+    return new Response(JSON.stringify({ error: "postSlug and postTitle are required" }), { status: 400 });
+  }
+
+  let userId = await getUserId(clerkId);
+  if (!userId) {
+    const [newUser] = await db.insert(users).values({ clerkId, email: "" }).returning({ id: users.id });
+    userId = newUser.id;
+  }
+
+  const existing = await db
+    .select({ id: visits.id })
+    .from(visits)
+    .where(and(eq(visits.userId, userId), eq(visits.postSlug, postSlug)))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return new Response(JSON.stringify({ visited: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  await db.insert(visits).values({
+    userId,
+    postSlug,
+    postTitle,
+    postRating: postRating ?? null,
+    notes: notes ?? null,
+  });
+
+  return new Response(JSON.stringify({ visited: true }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/pages/api/visits/[slug].test.ts
+++ b/src/pages/api/visits/[slug].test.ts
@@ -1,0 +1,54 @@
+import type { APIContext } from "astro";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../../lib/db", () => ({
+  db: {
+    select: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { db } from "../../../lib/db";
+import { DELETE } from "./[slug]";
+
+function makeContext(clerkId: string | null, slug = "test-slug"): APIContext {
+  return {
+    locals: { auth: () => ({ userId: clerkId }) },
+    params: { slug },
+  } as unknown as APIContext;
+}
+
+function makeSelectChain(result: unknown[] = []) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("DELETE /api/visits/[slug]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("returns 401 when unauthenticated", async () => {
+    const response = await DELETE(makeContext(null));
+    expect(response.status).toBe(401);
+    expect((await response.json()).error).toBe("Unauthorized");
+  });
+
+  test("returns 404 when the user is not found in the database", async () => {
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([]) as never);
+    const response = await DELETE(makeContext("clerk_abc", "some-post-slug"));
+    expect(response.status).toBe(404);
+  });
+
+  test("deletes the visit and returns 204", async () => {
+    vi.mocked(db.select).mockReturnValue(makeSelectChain([{ id: "user-uuid" }]) as never);
+    vi.mocked(db.delete).mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const response = await DELETE(makeContext("clerk_abc", "some-post-slug"));
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+});

--- a/src/pages/api/visits/[slug].ts
+++ b/src/pages/api/visits/[slug].ts
@@ -1,0 +1,23 @@
+import type { APIContext } from "astro";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../../lib/db";
+import { users, visits } from "../../../lib/schema";
+
+export async function DELETE(context: APIContext) {
+  const { userId: clerkId } = context.locals.auth();
+
+  if (!clerkId) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const { slug } = context.params;
+
+  const [user] = await db.select({ id: users.id }).from(users).where(eq(users.clerkId, clerkId)).limit(1);
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Not found" }), { status: 404 });
+  }
+
+  await db.delete(visits).where(and(eq(visits.userId, user.id), eq(visits.postSlug, slug!)));
+
+  return new Response(null, { status: 204 });
+}


### PR DESCRIPTION
## Summary

First slice of #453 (Roast Dinner Passport). Adds a personal visit log so logged-in users can mark a reviewed restaurant as "visited", separate from the existing wishlist.

- New `visits` Drizzle table (`postSlug`, `postTitle`, `postRating`, `visitedAt`, `notes`), unique per `(userId, postSlug)` — mirrors `wishlistItems`
- `GET/POST /api/visits` and `DELETE /api/visits/[slug]`, same auth pattern as the wishlist API
- New `VisitButton` Alpine component ("Mark as visited" / "Visited" toggle), wired in next to `WishlistButton` on `[slug].astro`
- Migration generated via `drizzle-kit generate`

Deliberately scoped small — badges, the `/my-passport` page, shareable OG cards, and the leaderboard from the issue are separate follow-up work.

## Test plan
- [x] `yarn test` — new visits tests pass (10/10); one pre-existing unrelated failure in `search.test.ts` confirmed present on `main` too
- [x] `yarn lint:errors` — clean
- [x] `yarn ts-check` — 0 errors
- [ ] Manual: sign in, open a review page, click "Mark as visited", confirm it persists and can be un-marked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
