### PR TITLE
fix(a11y+seo): accessibility and SEO fixes

### DIFF
--- a/src/components/add-comment/add-comment.astro
+++ b/src/components/add-comment/add-comment.astro
@@ -23,7 +23,7 @@ const { postId, parentId } = Astro.props as Props;
     <label for={`commentText-${parentId}`}>Comment:</label>
     <textarea name="commentText" id={`commentText-${parentId}`} required></textarea>
   </div>
-  <button class="reply-button" data-button-id={parentId}>Post Reply</button>
+  <button type="button" class="reply-button" data-button-id={parentId}>Post Reply</button>
   <p role="status" aria-live="polite" aria-atomic="true"></p>
 </form>
 

--- a/src/components/newsletter/newsletter.astro
+++ b/src/components/newsletter/newsletter.astro
@@ -3,7 +3,7 @@ const isTesting = import.meta.env.PLAYWRIGHT === "true";
 ---
 
 <div class="post-summary-block highlight-block substack-signup">
-  <p class="substack-signup-heading">📬 Get new roast reviews direct to your inbox</p>
+  <h2 class="substack-signup-heading">📬 Get new roast reviews direct to your inbox</h2>
   {!isTesting && (
     <iframe
       src="https://rdldn.substack.com/embed"

--- a/src/components/sort-posts/sort-posts.test.tsx
+++ b/src/components/sort-posts/sort-posts.test.tsx
@@ -107,7 +107,7 @@ const waitForRender = async () => {
 
 const getRoastTitles = (host: HTMLDivElement) =>
   Array.from(host.querySelectorAll('[data-test-id="roast-link"]')).map((el) =>
-    (el.textContent ?? "").trim()
+    (el.textContent ?? "").replace(/\s*\(Closed\)\s*$/, "").trim()
   );
 
 beforeEach(() => {

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -352,6 +352,9 @@ const SortPosts = ({
                 data-test-id="roast-link"
               >
                 {post.title}
+                {post.closedDowns?.nodes[0]?.name && (
+                  <span className="sr-only"> (Closed)</span>
+                )}
               </a>
               <span
                 className={`${post.closedDowns?.nodes[0]?.name ? "closed-down" : ""}`}

--- a/src/components/sunday-roast-planner/sunday-roast-planner.tsx
+++ b/src/components/sunday-roast-planner/sunday-roast-planner.tsx
@@ -223,6 +223,7 @@ const SundayRoastPlanner = ({
             <button
               type="button"
               className={`planner__tab ${locationType === "area" ? "planner__tab--active" : ""}`}
+              aria-pressed={locationType === "area"}
               onClick={() => switchLocationType("area")}
             >
               By area
@@ -230,6 +231,7 @@ const SundayRoastPlanner = ({
             <button
               type="button"
               className={`planner__tab ${locationType === "borough" ? "planner__tab--active" : ""}`}
+              aria-pressed={locationType === "borough"}
               onClick={() => switchLocationType("borough")}
             >
               By borough
@@ -237,6 +239,7 @@ const SundayRoastPlanner = ({
             <button
               type="button"
               className={`planner__tab ${locationType === "tubeLine" ? "planner__tab--active" : ""}`}
+              aria-pressed={locationType === "tubeLine"}
               onClick={() => switchLocationType("tubeLine")}
             >
               By tube line

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,6 +12,7 @@ const {
   halloween,
   structuredData,
   ogType = "website",
+  noindex = false,
 } = Astro.props;
 
 const canonicalURL = Astro.site
@@ -68,6 +69,7 @@ const canonicalURL = Astro.site
           title: pageTitle || "Roast Dinners In London",
           type: ogType,
           image: opengraphImage || logo1.src,
+          url: canonicalURL,
         },
         optional: {
           description:
@@ -83,8 +85,11 @@ const canonicalURL = Astro.site
           description ||
           "Lord Gravy bringing you a guide to the best and worst roast dinners in London.",
         image: opengraphImage || logo1.src,
+        imageAlt: pageTitle || "Roast Dinners In London",
       }}
     />
+    <meta property="og:locale" content="en_GB" />
+    {noindex && <meta name="robots" content="noindex" />}
     {
       structuredData && (
         <script

--- a/src/pages/flags.astro
+++ b/src/pages/flags.astro
@@ -27,8 +27,8 @@ const flags = Object.entries(FLAG_DEFINITIONS).map(([key, def]) => ({
 }));
 ---
 
-<BaseLayout pageTitle="Feature Flags" description="Control feature flags for this site.">
-  <main class="flags-page">
+<BaseLayout pageTitle="Feature Flags" description="Control feature flags for this site." noindex={true}>
+  <div class="flags-page">
     <h2>Feature Flags</h2>
     <p class="flags-intro">Changes take effect immediately.</p>
     <form method="POST" id="flags-form">
@@ -54,7 +54,7 @@ const flags = Object.entries(FLAG_DEFINITIONS).map(([key, def]) => ({
         }
       </ul>
     </form>
-  </main>
+  </div>
   <script>
     document.querySelectorAll(".flag-checkbox").forEach((checkbox) => {
       checkbox.addEventListener("change", () => {

--- a/src/pages/guessthescore/index.astro
+++ b/src/pages/guessthescore/index.astro
@@ -175,12 +175,13 @@ const submitToken = `${nonce}:${timestamp}:${sig}`;
 
         <!-- Score submission -->
         <div x-show="!scoreSubmitted" class="score-submit">
-          <p class="score-submit-prompt">
+          <label for="player-name-input" class="score-submit-prompt">
             Enter your name for the leaderboard:
-          </p>
+          </label>
           <div class="score-submit-row">
             <input
               type="text"
+              id="player-name-input"
               x-model="playerName"
               placeholder="Your name"
               maxlength="30"

--- a/src/pages/my-roasts.astro
+++ b/src/pages/my-roasts.astro
@@ -40,6 +40,7 @@ try {
 <BaseLayout
   pageTitle="My Roast List"
   description="Your saved roast dinner restaurants"
+  noindex={true}
 >
   <FeaturedPostHeader
     imageSrc={dreamingOfRoastDinners.src}

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -9,6 +9,7 @@ import "./sign-in.css";
 <BaseLayout
   pageTitle="Sign In"
   description="Sign in to your Roast Dinners in London account to manage your wishlist and roast list."
+  noindex={true}
 >
   <div class="sign-in-container">
     <ClerkSignIn />


### PR DESCRIPTION
## Summary

Fixes from the Thursday accessibility & SEO audit (2026-07-09). All changes are conservative and targeted at confirmed issues.

### SEO

- **`BaseLayout.astro`**: Add `og:url` (was completely absent — every page was missing this Open Graph tag), `og:locale=en_GB`, and `twitter:image:alt`. Add a `noindex` prop that conditionally emits `<meta name="robots" content="noindex">`.
- **`flags.astro`, `sign-in.astro`, `my-roasts.astro`**: Pass `noindex={true}` — the feature-flag admin UI, sign-in page, and authenticated wishlist page should not be indexed by search engines.

### Accessibility — invalid HTML

- **`flags.astro`**: Replace the nested `<main class="flags-page">` with `<div class="flags-page">`. `BaseLayout` already wraps its slot in `<main id="main-content">`, so the previous markup produced two nested `<main>` elements, which is invalid HTML and causes unpredictable screen reader behaviour.

### Accessibility — form correctness

- **`add-comment.astro`**: Add `type="button"` to the reply button. Buttons inside a `<form>` default to `type="submit"`; the JS intercept (`event.preventDefault()`) was masking this, but making the intent explicit removes a fragile implicit dependency.
- **`guessthescore/index.astro`**: Convert the `<p>` prompt before the player-name input into a `<label for="player-name-input">` and add `id="player-name-input"` to the input. `placeholder` is not a substitute for a label — screen readers navigating to the field previously had no context.

### Accessibility — ARIA state

- **`sunday-roast-planner.tsx`**: Add `aria-pressed={locationType === "area/borough/tubeLine"}` to each location-type tab button. The active state was communicated only via a CSS class; screen reader users had no way to know which option was selected.
- **`sort-posts.tsx`**: Add `<span className="sr-only"> (Closed)</span>` inside links for closed-down restaurants. The "closed" state was conveyed only by a CSS class (strikethrough / greyed style); screen readers were completely unaware.

### Accessibility — semantic HTML

- **`newsletter.astro`**: Promote the Substack signup heading from `<p class="substack-signup-heading">` to `<h2 class="substack-signup-heading">`. It was styled to look like a heading but was semantically a paragraph, invisible to screen reader heading navigation and search engine crawlers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UffseMrgofwgUPDx1NNSqG)_