### PR TITLE
fix: hide wishlist/visit sign-in prompts when authFeatures flag is off

### DIFF
--- a/src/components/visit-button/visit-button.astro
+++ b/src/components/visit-button/visit-button.astro
@@ -12,6 +12,7 @@ import "./visit-button.css";
 
 <div
   x-data={`visitButton(${JSON.stringify({ postSlug, postTitle, postRating: postRating ?? null })})`}
+  x-show="flagEnabled"
 >
   <a x-show="signedOut" href="/sign-in" class="visit-btn visit-sign-in"
     >Sign in to log a visit</a

--- a/src/components/wishlist-button/wishlist-button.astro
+++ b/src/components/wishlist-button/wishlist-button.astro
@@ -12,6 +12,7 @@ import "./wishlist-button.css";
 
 <div
   x-data={`wishlistButton(${JSON.stringify({ postSlug, postTitle, postRating: postRating ?? null })})`}
+  x-show="flagEnabled"
 >
   <a x-show="signedOut" href="/sign-in" class="wishlist-btn wishlist-sign-in"
     >Sign in to save this to your list</a

--- a/src/components/wishlist-button/wishlist-button.test.tsx
+++ b/src/components/wishlist-button/wishlist-button.test.tsx
@@ -27,9 +27,18 @@ const createHost = () => {
   return { host, root: createRoot(host) };
 };
 
+const setCookie = (value: string) => {
+  document.cookie = `flag_authFeatures=${value}; path=/`;
+};
+
+const clearCookie = () => {
+  document.cookie = "flag_authFeatures=; max-age=0; path=/";
+};
+
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  setCookie("true");
   global.fetch = vi.fn().mockResolvedValue({
     json: vi.fn().mockResolvedValue([]),
   });
@@ -37,9 +46,25 @@ beforeEach(() => {
 
 afterEach(() => {
   document.body.innerHTML = "";
+  clearCookie();
 });
 
 describe("WishlistButton", () => {
+  test("renders nothing when the auth features flag is off, even when signed out", async () => {
+    setCookie("false");
+    mockUseAuth.mockReturnValue({ isSignedIn: false, isLoaded: true });
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<WishlistButton postSlug="test-slug" postTitle="Test Post" />);
+    });
+    await waitForEffects();
+
+    expect(host.innerHTML).toBe("");
+
+    await act(async () => root.unmount());
+  });
+
   test("renders nothing while Clerk has not finished loading", async () => {
     mockUseAuth.mockReturnValue({ isSignedIn: false, isLoaded: false });
 

--- a/src/components/wishlist-button/wishlist-button.tsx
+++ b/src/components/wishlist-button/wishlist-button.tsx
@@ -2,6 +2,16 @@ import { useAuth } from "@clerk/astro/react";
 import { useEffect, useState } from "react";
 import "./wishlist-button.css";
 
+function useAuthFlag(): boolean | null {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
+    const val = match ? match[2] : null;
+    setEnabled(val === null ? false : val === "true");
+  }, []);
+  return enabled;
+}
+
 type Props = {
   postSlug: string;
   postTitle: string;
@@ -12,6 +22,7 @@ type Props = {
 };
 
 export default function WishlistButton({ postSlug, postTitle, postRating, iconOnly = false, isSaved, onSaveToggle }: Props) {
+  const flagEnabled = useAuthFlag();
   const { isSignedIn, isLoaded } = useAuth();
   const [saved, setSaved] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -36,7 +47,7 @@ export default function WishlistButton({ postSlug, postTitle, postRating, iconOn
       .finally(() => setLoading(false));
   }, [isLoaded, isSignedIn, postSlug, controlled]);
 
-  if (!isLoaded || loading) return null;
+  if (!flagEnabled || !isLoaded || loading) return null;
 
   if (!isSignedIn) {
     if (iconOnly) return null;

--- a/src/entrypoints/alpine.ts
+++ b/src/entrypoints/alpine.ts
@@ -13,6 +13,12 @@ type VisitButtonProps = {
   postRating: string | null;
 };
 
+function isAuthFeaturesFlagEnabled(): boolean {
+  const match = document.cookie.match(/(^| )flag_authFeatures=([^;]+)/);
+  const val = match ? match[2] : null;
+  return val === "true";
+}
+
 export default (alpine: AlpineInstance) => {
   (window as unknown as { Alpine: AlpineInstance }).Alpine = alpine;
 
@@ -21,9 +27,11 @@ export default (alpine: AlpineInstance) => {
     return {
       saved: false,
       signedOut: false,
+      flagEnabled: isAuthFeaturesFlagEnabled(),
       loading: false,
 
       async init() {
+        if (!this.flagEnabled) return;
         const clerk = (window as unknown as { Clerk?: ClerkInstance }).Clerk;
         if (!clerk) {
           this.signedOut = true;
@@ -76,9 +84,11 @@ export default (alpine: AlpineInstance) => {
     return {
       visited: false,
       signedOut: false,
+      flagEnabled: isAuthFeaturesFlagEnabled(),
       loading: false,
 
       async init() {
+        if (!this.flagEnabled) return;
         const clerk = (window as unknown as { Clerk?: ClerkInstance }).Clerk;
         if (!clerk) {
           this.signedOut = true;


### PR DESCRIPTION
## Summary
- The wishlist and visit buttons (React `WishlistButton` + Alpine `wishlist-button.astro` / `visit-button.astro`) only checked Clerk sign-in state, not the `authFeatures` flag, so the "Sign in to save this to your list" / "Sign in to log a visit" prompts still rendered even when the flag was disabled.
- Gated all three on the `flag_authFeatures` cookie, matching the existing pattern used by `HeaderAuth.tsx` / `MyRoastListItem.tsx`.

## Test plan
- [x] `yarn vitest run src/components/wishlist-button src/entrypoints` — passes, added a test asserting nothing renders when the flag is off even while signed out
- [x] `yarn vitest run src/components/sunday-roast-planner src/components/sort-posts src/components/visit-button src/components/my-roast-list-item src/components/header` — passes
- [x] `yarn astro check` — no new errors
- [ ] Manual: toggle `authFeatures` off via `/flags`, visit a post page signed out, confirm neither sign-in prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
