### PR TITLE
feat: "Explore the Data" — contextual deep-links from reviews into the league table

### DIFF
--- a/src/components/explore-data-section/explore-data-section.astro
+++ b/src/components/explore-data-section/explore-data-section.astro
@@ -1,0 +1,41 @@
+---
+type Props = {
+  borough?: string;
+  meat?: string;
+  rating?: string;
+};
+
+const { borough, meat, rating } = Astro.props;
+const hasHighRating = rating !== undefined && Number(rating) >= 7;
+---
+
+{
+  (borough || meat || hasHighRating) && (
+    <section class="explore-data" aria-labelledby="explore-heading">
+      <h3 id="explore-heading">Explore more:</h3>
+      <ul>
+        {borough && (
+          <li>
+            <a href={`/league-of-roasts?borough=${encodeURIComponent(borough)}&closedDown=open`}>
+              All open roast dinners in {borough} →
+            </a>
+          </li>
+        )}
+        {meat && (
+          <li>
+            <a href={`/league-of-roasts?meat=${encodeURIComponent(meat)}`}>
+              All {meat} roasts in London →
+            </a>
+          </li>
+        )}
+        {hasHighRating && (
+          <li>
+            <a href={`/league-of-roasts?score=${Math.floor(Number(rating))}`}>
+              All roasts rated {Math.floor(Number(rating))}+ in London →
+            </a>
+          </li>
+        )}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/explore-data-section/explore-data-section.test.ts
+++ b/src/components/explore-data-section/explore-data-section.test.ts
@@ -1,0 +1,39 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, test } from "vitest";
+
+describe("explore-data-section component", () => {
+  test("renders links for borough, meat, and a high rating", async () => {
+    const container = await AstroContainer.create();
+    const { default: ExploreDataSection } = await import("./explore-data-section.astro");
+    const html = await container.renderToString(ExploreDataSection, {
+      props: { borough: "Hackney", meat: "Beef", rating: "8.5" },
+    });
+
+    expect(html).toContain("Explore more:");
+    expect(html).toContain('href="/league-of-roasts?borough=Hackney&amp;closedDown=open"');
+    expect(html).toContain('href="/league-of-roasts?meat=Beef"');
+    expect(html).toContain('href="/league-of-roasts?score=8"');
+  });
+
+  test("omits the rating link when rating is below 7", async () => {
+    const container = await AstroContainer.create();
+    const { default: ExploreDataSection } = await import("./explore-data-section.astro");
+    const html = await container.renderToString(ExploreDataSection, {
+      props: { borough: "Camden", meat: "Lamb", rating: "6.9" },
+    });
+
+    expect(html).toContain('href="/league-of-roasts?borough=Camden&amp;closedDown=open"');
+    expect(html).toContain('href="/league-of-roasts?meat=Lamb"');
+    expect(html).not.toContain("league-of-roasts?score=");
+  });
+
+  test("renders nothing when no borough, meat, or qualifying rating is provided", async () => {
+    const container = await AstroContainer.create();
+    const { default: ExploreDataSection } = await import("./explore-data-section.astro");
+    const html = await container.renderToString(ExploreDataSection, {
+      props: {},
+    });
+
+    expect(html).not.toContain("explore-data");
+  });
+});

--- a/src/components/roastByTagSection/roast-by-tag-section.astro
+++ b/src/components/roastByTagSection/roast-by-tag-section.astro
@@ -25,7 +25,7 @@ if (tag) {
             (size: Size) => size.name === "homepage"
           )?.sourceUrl || edge.featuredImage?.node?.sourceUrl,
       }))
-      .sort(() => Math.random() - 0.5)
+      .sort((a, b) => Number(b.ratings?.nodes[0]?.name ?? 0) - Number(a.ratings?.nodes[0]?.name ?? 0))
       .slice(0, 3);
   } catch (error) {
     console.error("Error fetching other posts:", error);

--- a/src/lib/queries/singlePostBySlug.ts
+++ b/src/lib/queries/singlePostBySlug.ts
@@ -37,6 +37,11 @@ const SINGLE_POST_QUERY = (slug: string) => `
           name
         }
       }
+      meats {
+        nodes {
+          name
+        }
+      }
       tubeStations {
         nodes {
           name

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -16,6 +16,7 @@ import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import sanitizeHtml from "sanitize-html";
 import Comments from "../components/comments/comments.astro";
+import ExploreDataSection from "../components/explore-data-section/explore-data-section.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
 import Newsletter from "../components/newsletter/newsletter.astro";
 import RoastByTagSection from "../components/roastByTagSection/roast-by-tag-section.astro";
@@ -134,6 +135,8 @@ const inflationAdjustedPrice =
     ? `~£${(rawPrice * inflationMultiplier).toFixed(2)}`
     : null;
 const rating = post.ratings?.nodes?.[0]?.name;
+const borough = post.boroughs?.nodes?.[0]?.name;
+const meat = post.meats?.nodes?.[0]?.name;
 const tubeStation = post.tubeStations?.nodes?.[0]?.name;
 const tubeLines = post.tubeLines?.nodes?.map((line: { name: string }) => line.name).join(", ");
 const isRoastDinner = post.typesOfPost?.nodes?.some((node: { name: string }) => node.name === "Roast Dinner");
@@ -331,6 +334,9 @@ const reviewStructuredData =
         </>
       )}
     </section>
+
+    <ExploreDataSection borough={borough} meat={meat} rating={rating} />
+
     <WishlistButton
       postSlug={String(slug)}
       postTitle={singlePost.title ?? ""}

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -55,6 +55,17 @@ section {
     }
   }
 
+  &.explore-data {
+    ul {
+      gap: 0.5rem;
+    }
+
+    a {
+      color: var(--roast-new-blue);
+      text-decoration: underline;
+    }
+  }
+
   &.roast-by-tag {
     ul {
       display: flex;


### PR DESCRIPTION
## Summary
- Adds an "Explore more" section to each roast dinner review page, after the summary block, with contextual deep-links into `/league-of-roasts` pre-filtered by borough (open only), meat, and rating band (7+)
- Fixes `RoastByTagSection` to sort candidate posts by rating (descending) before slicing to 3, instead of randomly shuffling — the "Roasts in [Borough]" widget now always shows the best picks
- Extracted the new links into a dedicated `ExploreDataSection` component (mirroring the existing `RoastByTagSection` pattern) that renders unconditionally and decides internally whether it has anything to show — this was required to work around an Astro→TSX compiler issue where a top-level `{condition && (...)}` JSX expression sibling to the page's other self-closing components broke `astro check`

Closes #456

## Test plan
- [x] `yarn vitest run` — 412 tests pass, including new `explore-data-section.test.ts`
- [x] `yarn astro check` — 0 errors
- [x] `yarn lint:errors` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)