### PR TITLE
a11y: restore focus-visible outline on select elements

### DIFF
--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -307,14 +307,14 @@ section {
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+select:focus-visible {
   outline: 3px solid var(--roast-pink);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
-input:focus-visible,
-select:focus-visible {
+input:focus-visible {
   outline: none;
 }
 


### PR DESCRIPTION
## What

Move `select:focus-visible` out of the `outline: none` rule and into the existing pink-outline rule, so keyboard-focused `<select>` elements show the same 3 px pink ring as links and buttons.

## Why

**WCAG Criterion:** 2.4.7 Focus Visible — Level AA

Keyboard users (and switch-access users) rely on a visible focus indicator to know which control is active. Every `<select>` on the site — the nine filter/sort dropdowns on the League of Roasts page, the filter selects on Best Value, and the search selects — had their browser focus ring silently removed by:

```css
input:focus-visible,
select:focus-visible {
  outline: none;   /* ← kills the ring for selects with no replacement */
}
```

`input` elements were fine because `input:focus { border: 2px solid var(--roast-pink) }` provides a substitute indicator. `select` elements had no such fallback.

## Change

- `src/layouts/layout.css` — add `select:focus-visible` to the positive `outline: 3px solid var(--roast-pink)` rule; remove it from the `outline: none` rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7EMUyk4c3uRiHk7sJx4x5)_