### PR TITLE
fix(a11y): restore focus-visible rings on select and range slider

### DIFF
--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -307,14 +307,14 @@ section {
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+select:focus-visible {
   outline: 3px solid var(--roast-pink);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
-input:focus-visible,
-select:focus-visible {
+input:focus-visible {
   outline: none;
 }
 

--- a/src/pages/guessthescore/game.css
+++ b/src/pages/guessthescore/game.css
@@ -206,6 +206,11 @@
   border: none;
   margin: 0;
 
+  &:focus-visible {
+    box-shadow: 0 0 0 3px var(--roast-pink);
+    border-radius: 4px;
+  }
+
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;


### PR DESCRIPTION
## Summary

Two interactive controls had their browser focus rings suppressed (`outline: none`) with no visible replacement, breaking keyboard navigation for those elements.

- **`src/layouts/layout.css`** — `select:focus-visible` was grouped with `input:focus-visible` under `outline: none`. Select elements now receive the same 3 px pink outline (`var(--roast-pink)`) used by buttons and links across the site. This was a WCAG 2.4.7 (Focus Visible, Level AA) failure affecting every `<select>` on the site.

- **`src/pages/guessthescore/game.css`** — `.score-slider` (the range input in the Guess the Score game) had `outline: none` with no replacement. Added a `:focus-visible` rule using `box-shadow: 0 0 0 3px var(--roast-pink)` so keyboard users can see when the slider is focused.

Both fixes use the site's existing pink focus colour so they are visually consistent with all other interactive elements.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7EMUyk4c3uRiHk7sJx4x5)_