### PR TITLE
chore(nav): remove Best Value Roasts link from header

### DIFF
--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -55,7 +55,6 @@ const isTesting = import.meta.env.PLAYWRIGHT === "true";
 
     <nav id="nav-menu" aria-label="Main navigation">
       <a href="/league-of-roasts" aria-current={currentPath === "/league-of-roasts" ? "page" : undefined}>League Of Roasts</a>
-      <a href="/best-value-roast-dinners-london" aria-current={currentPath === "/best-value-roast-dinners-london" ? "page" : undefined}>Best Value Roasts</a>
       <a href="/best-roast-lists" aria-current={currentPath === "/best-roast-lists" ? "page" : undefined}>Best Roasts Lists</a>
       <a href="/maps" aria-current={currentPath === "/maps" ? "page" : undefined}>Maps</a>
       <a href="/to-do-list" aria-current={currentPath === "/to-do-list" ? "page" : undefined}>To-Do List</a>


### PR DESCRIPTION
## Summary
- Removes the "Best Value Roasts" link from the main navigation bar

## Test plan
- [x] Visually confirmed link no longer renders in nav markup