### PR TITLE
fix: retry transient GraphQL failures to stabilize CI (axe + e2e)

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -158,6 +158,105 @@ describe("fetchGraphQL", () => {
     await expect(fetchGraphQL("{ me }")).rejects.toThrow(JSON.stringify(errors));
   });
 
+  it("retries on a transient 503 response and succeeds once the backend recovers", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({ ok: false, status: 503, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue({ data: { posts: [] } }),
+        })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    const resultPromise = fetchGraphQL(query);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toEqual({ posts: [] });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("retries when the response body is not valid JSON (e.g. an HTML maintenance page)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token '<'")),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue({ data: { posts: [] } }),
+        })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    const resultPromise = fetchGraphQL(query);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toEqual({ posts: [] });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("stops retrying after the max attempts and throws, evicting the cache entry", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: vi.fn().mockResolvedValue({}) })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    const resultPromise = fetchGraphQL(query);
+    const assertion = expect(resultPromise).rejects.toThrow("GraphQL Error");
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+
+    // A subsequent call should re-fetch rather than reuse the evicted, rejected entry.
+    vi.unstubAllGlobals();
+    mockFetch({ posts: [] });
+    const result = await fetchGraphQL(query);
+    expect(result).toEqual({ posts: [] });
+  });
+
+  it("does not retry on a non-retryable 4xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 400, json: vi.fn().mockResolvedValue({}) })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    await expect(fetchGraphQL(query)).rejects.toThrow("GraphQL Error");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on a real GraphQL errors array", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ errors: [{ message: "Not found" }] }),
+      })
+    );
+    const query = "{ posts { nodes { slug } } }";
+
+    await expect(fetchGraphQL(query)).rejects.toThrow("GraphQL Error");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("resetGraphQLRequestCache clears the cache so subsequent calls re-fetch", async () => {
     mockFetch({ posts: [] });
     const query = "{ posts { nodes { slug } } }";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -24,6 +24,71 @@ const getRequestCacheKey = (
   variables: Record<string, unknown>
 ): string => `${query}::${stableStringify(variables)}`;
 
+// The WordPress backend occasionally returns transient 5xx responses (or an
+// HTML maintenance page instead of JSON) during brief outages. These are
+// worth retrying; a malformed query or a real GraphQL error is not.
+class RetryableGraphQLError extends Error {}
+
+const RETRYABLE_STATUSES = new Set([502, 503, 504]);
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 500;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchGraphQLOnce<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const response = await fetch(import.meta.env.PUBLIC_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  let json: { data?: T; errors?: unknown };
+  try {
+    json = await response.json();
+  } catch {
+    throw new RetryableGraphQLError(
+      `GraphQL Error: non-JSON response (status ${response.status})`
+    );
+  }
+
+  if (!response.ok) {
+    const errorMsg = `GraphQL Error: Unknown error. Response: ${JSON.stringify(json)}`;
+    if (RETRYABLE_STATUSES.has(response.status)) {
+      throw new RetryableGraphQLError(errorMsg);
+    }
+    throw new Error(errorMsg);
+  }
+
+  if (json.errors) {
+    throw new Error(`GraphQL Error: ${JSON.stringify(json.errors)}`);
+  }
+
+  return json.data as T;
+}
+
+async function fetchGraphQLWithRetry<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fetchGraphQLOnce<T>(query, variables);
+    } catch (error) {
+      const isLastAttempt = attempt === MAX_ATTEMPTS;
+      if (!(error instanceof RetryableGraphQLError) || isLastAttempt) {
+        throw error;
+      }
+      await delay(RETRY_DELAY_MS * attempt);
+    }
+  }
+
+  // Unreachable: the loop always returns or throws.
+  throw new Error("GraphQL Error: retry loop exhausted unexpectedly");
+}
+
 export async function fetchGraphQL<T = unknown>(
   query: string,
   variables: Record<string, unknown> = {}
@@ -35,24 +100,7 @@ export async function fetchGraphQL<T = unknown>(
     return (await existingRequest) as T;
   }
 
-  const requestPromise = (async () => {
-    const response = await fetch(import.meta.env.PUBLIC_GRAPHQL_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query, variables }),
-    });
-
-    const json = await response.json();
-
-    if (!response.ok || json.errors) {
-      const errorMsg = json.errors
-        ? `GraphQL Error: ${JSON.stringify(json.errors)}`
-        : `GraphQL Error: Unknown error. Response: ${JSON.stringify(json)}`;
-      throw new Error(errorMsg);
-    }
-
-    return json.data;
-  })();
+  const requestPromise = fetchGraphQLWithRetry<T>(query, variables);
 
   graphQLRequestCache.set(cacheKey, requestPromise);
 


### PR DESCRIPTION
## Summary

Closes #520 (Axe on CI keeps failing) and closes #521 (e2e smoke test failing on chromium/webkit).

Both issues trace back to the same root cause: the WordPress GraphQL backend intermittently returns `502/503/504` (or an HTML "scheduled maintenance" page instead of JSON) during brief outages.

- The **axe** job's `yarn build` step failed outright with `GraphQL Error: Unknown error. Response: {"code":"wp_die","message":"Briefly unavailable for scheduled maintenance...`, aborting the static build before axe could even run.
- The **e2e-tests** job runs against a live `yarn dev` server (see `playwright.config.ts`), so every page render makes a real SSR call to the WordPress API. A single flaky response during the run (`Error fetching location pages: SyntaxError: Unexpected token '<', "<html>`) cascaded into ~54 failing tests across chromium/firefox/webkit — not a real bug in any individual test.

`fetchGraphQL` (`src/lib/api.ts`) had no retry logic, so any transient upstream hiccup failed the whole build/request immediately.

## Changes

- `fetchGraphQL` now retries up to 3 times with a linear backoff (500ms, 1000ms) when the backend returns a `502/503/504` status or a non-JSON response body (e.g. an HTML maintenance page).
- Real GraphQL errors (a valid `errors` array in the response) and non-retryable 4xx responses still fail immediately, same as before — only genuinely transient failures are retried.
- Added unit tests covering: retry-then-succeed on 503, retry-then-succeed on a non-JSON body, exhausting retries and still throwing (with cache eviction so a later call can retry fresh), and confirming 4xx / real GraphQL errors are *not* retried.

## Test plan

- [x] `npx vitest run` — full suite passes (430 tests, including 5 new retry tests)
- [x] `npx biome check src/lib/api.ts src/lib/api.test.ts` — no issues
- [x] `npx astro check` — 0 errors, 0 warnings
- [ ] Confirm CI's `axe` and `e2e-tests` jobs pass on this PR (this is exactly the flake this PR aims to fix, so it also serves as a live test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Xd5eVzDTEQ6N7yK6huWn)_