### PR TITLE
Add dynamic per-borough pages + Borough Hub

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,7 +13,7 @@ export const getPostRating = (post: Post): number =>
 export const isRoastDinnerPost = (post: Post): boolean =>
   post.typesOfPost?.nodes?.some((node) => node.name === "Roast Dinner") ?? false;
 
-const isClosedDownPost = (post: Post): boolean =>
+export const isClosedDownPost = (post: Post): boolean =>
   (post.closedDowns?.nodes?.length ?? 0) > 0;
 
 export const getTopRoastDinnerPosts = (

--- a/src/pages/best-roast-lists.astro
+++ b/src/pages/best-roast-lists.astro
@@ -80,6 +80,16 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     <div set:html={singlePage.content} />
 
     <section class="other-list">
+      <h3>Browse by Borough</h3>
+      <p>
+        <a href="/boroughs"
+          >See every London borough Lord Gravy has reviewed a roast dinner
+          in →</a
+        >
+      </p>
+    </section>
+
+    <section class="other-list">
       <h3>Best Roasts In...</h3>
       <ul>
         {

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -31,7 +31,7 @@ export async function getStaticPaths() {
 
   allPosts.forEach((post) => {
     const boroughName = post.boroughs?.nodes?.[0]?.name;
-    if (!boroughName) return;
+    if (!boroughName || boroughName.trim().toLowerCase() === "n/a") return;
 
     const boroughSlug = toOwnerSlug(boroughName);
     const current = postsByBorough.get(boroughSlug) ?? {
@@ -60,7 +60,7 @@ const { boroughName, posts } = Astro.props as BoroughPageProps;
 const ratings = posts.map(getPostRating).filter((r) => r > 0);
 const averageRating =
   ratings.length > 0
-    ? (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(1)
+    ? (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(2)
     : null;
 
 const prices = posts
@@ -72,7 +72,7 @@ const averagePrice =
     : null;
 
 const topPost = posts[0];
-const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts.length === 1 ? "" : "s"} in ${boroughName}.${averageRating ? ` Average rating: ${averageRating}/10.` : ""}${averagePrice ? ` Average price: £${averagePrice}.` : ""} Ranked by score.`;
+const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts.length === 1 ? "" : "s"} in ${boroughName}.${averageRating ? ` Average rating: ${averageRating}.` : ""}${averagePrice ? ` Average price: £${averagePrice}.` : ""} Ranked by score.`;
 ---
 
 <BaseLayout
@@ -95,7 +95,7 @@ const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts
         {
           averageRating && (
             <p>
-              <strong>Average rating:</strong> {averageRating}/10
+              <strong>Average rating:</strong> {averageRating}
             </p>
           )
         }

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -90,32 +90,30 @@ const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts
     imageAlt={topPost?.featuredImage?.node?.altText ||
       `Photo of the best roast dinner in ${boroughName}`}
     title={`Best Roast Dinners in ${boroughName}`}
-  >
-    <Fragment slot="meta">
-      <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
-      <div class="borough-summary">
-        <p>
-          <strong>Reviews:</strong> {posts.length}
-        </p>
-        {
-          averageRating && (
-            <p>
-              <strong>Average rating:</strong> {averageRating}
-            </p>
-          )
-        }
-        {
-          averagePrice && (
-            <p>
-              <strong>Average price:</strong> £{averagePrice}
-            </p>
-          )
-        }
-      </div>
-    </Fragment>
-  </FeaturedPostHeader>
+  />
 
   <div class="container borough-detail">
+    <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
+    <div class="borough-summary">
+      <p>
+        <strong>Reviews:</strong> {posts.length}
+      </p>
+      {
+        averageRating && (
+          <p>
+            <strong>Average rating:</strong> {averageRating}
+          </p>
+        )
+      }
+      {
+        averagePrice && (
+          <p>
+            <strong>Average price:</strong> £{averagePrice}
+          </p>
+        )
+      }
+    </div>
+
     <section class="home-list">
       <ul>
         {

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -80,76 +80,76 @@ const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts
   description={description}
   opengraphImage={topPost?.featuredImage?.node?.sourceUrl}
 >
-  <div class="borough-detail">
-    <FeaturedPostHeader
-      imageSrc={topPost?.featuredImage?.node?.sourceUrl || logo3.src}
-      imageAlt={topPost?.featuredImage?.node?.altText ||
-        `Photo of the best roast dinner in ${boroughName}`}
-      title={`Best Roast Dinners in ${boroughName}`}
-    >
-      <Fragment slot="meta">
-        <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
-        <div class="borough-summary">
-          <p>
-            <strong>Reviews:</strong> {posts.length}
-          </p>
-          {
-            averageRating && (
-              <p>
-                <strong>Average rating:</strong> {averageRating}/10
-              </p>
-            )
-          }
-          {
-            averagePrice && (
-              <p>
-                <strong>Average price:</strong> £{averagePrice}
-              </p>
-            )
-          }
-        </div>
-      </Fragment>
-    </FeaturedPostHeader>
-  </div>
-
-  <section class="home-list">
-    <ul>
-      {
-        posts.map((post, index) => (
-          <li class="heading" data-rating={post.ratings?.nodes?.[0]?.name || ""}>
-            <h3>
-              <span class="borough-rank">#{index + 1}</span>{" "}
-              <a href={`/${post.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={sanitizeTitle(post.title)} />
-              </a>
-            </h3>
-            <a
-              href={`/${post.slug}`}
-              rel="noopener noreferrer"
-              class="featured-image"
-            >
-              <img
-                src={post.featuredImage?.node?.sourceUrl}
-                alt={
-                  post.featuredImage?.node?.altText ||
-                  `Photo of the roast dinner at ${post.title}`
-                }
-                width="400"
-                height="300"
-                loading={index === 0 ? "eager" : "lazy"}
-              />
-            </a>
+  <FeaturedPostHeader
+    imageSrc={topPost?.featuredImage?.node?.sourceUrl || logo3.src}
+    imageAlt={topPost?.featuredImage?.node?.altText ||
+      `Photo of the best roast dinner in ${boroughName}`}
+    title={`Best Roast Dinners in ${boroughName}`}
+  >
+    <Fragment slot="meta">
+      <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
+      <div class="borough-summary">
+        <p>
+          <strong>Reviews:</strong> {posts.length}
+        </p>
+        {
+          averageRating && (
             <p>
-              <strong>Rating:</strong> {post.ratings?.nodes?.[0]?.name || "N/A"}
+              <strong>Average rating:</strong> {averageRating}/10
             </p>
-            {post.prices?.nodes?.[0]?.name && (
+          )
+        }
+        {
+          averagePrice && (
+            <p>
+              <strong>Average price:</strong> £{averagePrice}
+            </p>
+          )
+        }
+      </div>
+    </Fragment>
+  </FeaturedPostHeader>
+
+  <div class="container borough-detail">
+    <section class="home-list">
+      <ul>
+        {
+          posts.map((post, index) => (
+            <li class="heading" data-rating={post.ratings?.nodes?.[0]?.name || ""}>
+              <h3>
+                <span class="borough-rank">#{index + 1}</span>{" "}
+                <a href={`/${post.slug}`} rel="noopener noreferrer">
+                  <Fragment set:html={sanitizeTitle(post.title)} />
+                </a>
+              </h3>
+              <a
+                href={`/${post.slug}`}
+                rel="noopener noreferrer"
+                class="featured-image"
+              >
+                <img
+                  src={post.featuredImage?.node?.sourceUrl}
+                  alt={
+                    post.featuredImage?.node?.altText ||
+                    `Photo of the roast dinner at ${post.title}`
+                  }
+                  width="400"
+                  height="300"
+                  loading={index === 0 ? "eager" : "lazy"}
+                />
+              </a>
               <p>
-                <strong>Price:</strong> {post.prices.nodes[0].name}
+                <strong>Rating:</strong> {post.ratings?.nodes?.[0]?.name || "N/A"}
               </p>
-            )}
-          </li>
-        ))
-      }
-    </ul>
-  </section>
+              {post.prices?.nodes?.[0]?.name && (
+                <p>
+                  <strong>Price:</strong> {post.prices.nodes[0].name}
+                </p>
+              )}
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </div>
 </BaseLayout>

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -5,7 +5,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
 import { sanitizeTitle } from "../../lib/sanitize";
-import { getPostRating } from "../../lib/utils";
+import { getPostRating, isClosedDownPost } from "../../lib/utils";
 import "../../styles/post.css";
 import "../../styles/boroughs.css";
 import type { Post } from "../../types";
@@ -31,7 +31,12 @@ export async function getStaticPaths() {
 
   allPosts.forEach((post) => {
     const boroughName = post.boroughs?.nodes?.[0]?.name;
-    if (!boroughName || boroughName.trim().toLowerCase() === "n/a") return;
+    if (
+      !boroughName ||
+      boroughName.trim().toLowerCase() === "n/a" ||
+      isClosedDownPost(post)
+    )
+      return;
 
     const boroughSlug = toOwnerSlug(boroughName);
     const current = postsByBorough.get(boroughSlug) ?? {

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -1,9 +1,12 @@
 ---
+import FeaturedPostHeader from "../../components/featured-post-header/featured-post-header.astro";
+import logo3 from "../../images/logo-3.png";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
 import { sanitizeTitle } from "../../lib/sanitize";
 import { getPostRating } from "../../lib/utils";
+import "../../styles/post.css";
 import "../../styles/boroughs.css";
 import type { Post } from "../../types";
 
@@ -77,30 +80,36 @@ const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts
   description={description}
   opengraphImage={topPost?.featuredImage?.node?.sourceUrl}
 >
-  <div class="no-image-container borough-detail">
-    <section class="post-title centre-with-padding">
-      <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
-      <h2>Best Roast Dinners in {boroughName}</h2>
-      <div class="borough-summary">
-        <p>
-          <strong>Reviews:</strong> {posts.length}
-        </p>
-        {
-          averageRating && (
-            <p>
-              <strong>Average rating:</strong> {averageRating}/10
-            </p>
-          )
-        }
-        {
-          averagePrice && (
-            <p>
-              <strong>Average price:</strong> £{averagePrice}
-            </p>
-          )
-        }
-      </div>
-    </section>
+  <div class="borough-detail">
+    <FeaturedPostHeader
+      imageSrc={topPost?.featuredImage?.node?.sourceUrl || logo3.src}
+      imageAlt={topPost?.featuredImage?.node?.altText ||
+        `Photo of the best roast dinner in ${boroughName}`}
+      title={`Best Roast Dinners in ${boroughName}`}
+    >
+      <Fragment slot="meta">
+        <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
+        <div class="borough-summary">
+          <p>
+            <strong>Reviews:</strong> {posts.length}
+          </p>
+          {
+            averageRating && (
+              <p>
+                <strong>Average rating:</strong> {averageRating}/10
+              </p>
+            )
+          }
+          {
+            averagePrice && (
+              <p>
+                <strong>Average price:</strong> £{averagePrice}
+              </p>
+            )
+          }
+        </div>
+      </Fragment>
+    </FeaturedPostHeader>
   </div>
 
   <section class="home-list">

--- a/src/pages/boroughs/[borough].astro
+++ b/src/pages/boroughs/[borough].astro
@@ -1,0 +1,146 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
+import { toOwnerSlug } from "../../lib/ownerSlug";
+import { sanitizeTitle } from "../../lib/sanitize";
+import { getPostRating } from "../../lib/utils";
+import "../../styles/boroughs.css";
+import type { Post } from "../../types";
+
+export const prerender = true;
+
+type BoroughPageProps = {
+  boroughName: string;
+  posts: Post[];
+};
+
+const parsePrice = (priceStr: string | undefined): number | null => {
+  if (!priceStr) return null;
+  const match = priceStr.match(/[\d,.]+/);
+  if (!match) return null;
+  const price = Number.parseFloat(match[0].replace(",", ""));
+  return !Number.isNaN(price) && price > 0 ? price : null;
+};
+
+export async function getStaticPaths() {
+  const allPosts = await getAllRoastDinnerPosts();
+  const postsByBorough = new Map<string, BoroughPageProps>();
+
+  allPosts.forEach((post) => {
+    const boroughName = post.boroughs?.nodes?.[0]?.name;
+    if (!boroughName) return;
+
+    const boroughSlug = toOwnerSlug(boroughName);
+    const current = postsByBorough.get(boroughSlug) ?? {
+      boroughName,
+      posts: [],
+    };
+    current.posts.push(post);
+    postsByBorough.set(boroughSlug, current);
+  });
+
+  return [...postsByBorough.entries()]
+    .filter(([, data]) => data.posts.length >= 2)
+    .map(([borough, data]) => ({
+      params: { borough },
+      props: {
+        boroughName: data.boroughName,
+        posts: [...data.posts].sort(
+          (a, b) => getPostRating(b) - getPostRating(a)
+        ),
+      },
+    }));
+}
+
+const { boroughName, posts } = Astro.props as BoroughPageProps;
+
+const ratings = posts.map(getPostRating).filter((r) => r > 0);
+const averageRating =
+  ratings.length > 0
+    ? (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(1)
+    : null;
+
+const prices = posts
+  .map((p) => parsePrice(p.prices?.nodes?.[0]?.name))
+  .filter((p): p is number => p !== null);
+const averagePrice =
+  prices.length > 0
+    ? (prices.reduce((sum, p) => sum + p, 0) / prices.length).toFixed(2)
+    : null;
+
+const topPost = posts[0];
+const description = `Lord Gravy has reviewed ${posts.length} roast dinner${posts.length === 1 ? "" : "s"} in ${boroughName}.${averageRating ? ` Average rating: ${averageRating}/10.` : ""}${averagePrice ? ` Average price: £${averagePrice}.` : ""} Ranked by score.`;
+---
+
+<BaseLayout
+  pageTitle={`Best Roast Dinners in ${boroughName}, London`}
+  description={description}
+  opengraphImage={topPost?.featuredImage?.node?.sourceUrl}
+>
+  <div class="no-image-container borough-detail">
+    <section class="post-title centre-with-padding">
+      <a class="borough-back-link" href="/boroughs">← Browse all boroughs</a>
+      <h2>Best Roast Dinners in {boroughName}</h2>
+      <div class="borough-summary">
+        <p>
+          <strong>Reviews:</strong> {posts.length}
+        </p>
+        {
+          averageRating && (
+            <p>
+              <strong>Average rating:</strong> {averageRating}/10
+            </p>
+          )
+        }
+        {
+          averagePrice && (
+            <p>
+              <strong>Average price:</strong> £{averagePrice}
+            </p>
+          )
+        }
+      </div>
+    </section>
+  </div>
+
+  <section class="home-list">
+    <ul>
+      {
+        posts.map((post, index) => (
+          <li class="heading" data-rating={post.ratings?.nodes?.[0]?.name || ""}>
+            <h3>
+              <span class="borough-rank">#{index + 1}</span>{" "}
+              <a href={`/${post.slug}`} rel="noopener noreferrer">
+                <Fragment set:html={sanitizeTitle(post.title)} />
+              </a>
+            </h3>
+            <a
+              href={`/${post.slug}`}
+              rel="noopener noreferrer"
+              class="featured-image"
+            >
+              <img
+                src={post.featuredImage?.node?.sourceUrl}
+                alt={
+                  post.featuredImage?.node?.altText ||
+                  `Photo of the roast dinner at ${post.title}`
+                }
+                width="400"
+                height="300"
+                loading={index === 0 ? "eager" : "lazy"}
+              />
+            </a>
+            <p>
+              <strong>Rating:</strong> {post.ratings?.nodes?.[0]?.name || "N/A"}
+            </p>
+            {post.prices?.nodes?.[0]?.name && (
+              <p>
+                <strong>Price:</strong> {post.prices.nodes[0].name}
+              </p>
+            )}
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+</BaseLayout>

--- a/src/pages/boroughs/[borough].test.ts
+++ b/src/pages/boroughs/[borough].test.ts
@@ -1,0 +1,140 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
+import type { Post } from "../../types";
+
+vi.mock("../../components/header/HeaderAuth");
+
+vi.mock("../../lib/getAllRoastDinnerPosts", () => ({
+  getAllRoastDinnerPosts: vi.fn(),
+}));
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  ),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.mocked(getAllRoastDinnerPosts).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("borough detail page", () => {
+  test("getStaticPaths groups by borough, excludes boroughs with fewer than 2 posts, and sorts by rating descending", async () => {
+    vi.mocked(getAllRoastDinnerPosts).mockResolvedValue([
+      {
+        slug: "hackney-low",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "6.0" }] },
+      },
+      {
+        slug: "hackney-high",
+        date: "2025-02-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "9.0" }] },
+      },
+      {
+        slug: "solo-borough",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "Solo Borough" }] },
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+      {
+        slug: "no-borough",
+        date: "2025-01-01T00:00:00.000Z",
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+    ] as Post[]);
+
+    const pageModule = await import("./[borough].astro");
+    const paths = (await pageModule.getStaticPaths()) as Array<{
+      params: { borough: string };
+      props: { boroughName: string; posts: Post[] };
+    }>;
+
+    const hackney = paths.find((entry) => entry.params.borough === "hackney");
+    const solo = paths.find(
+      (entry) => entry.params.borough === "solo-borough"
+    );
+
+    expect(hackney).toBeDefined();
+    expect(solo).toBeUndefined();
+    expect(hackney?.props.boroughName).toBe("Hackney");
+    expect(hackney?.props.posts.map((post) => post.slug)).toEqual([
+      "hackney-high",
+      "hackney-low",
+    ]);
+  });
+
+  test("renders borough summary, ranked list, and price when available", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[borough].astro");
+
+    const html = await container.renderToString(Page, {
+      props: {
+        boroughName: "Hackney",
+        posts: [
+          {
+            slug: "hackney-high",
+            title: "Hackney High",
+            featuredImage: {
+              node: { sourceUrl: "https://example.com/high.jpg", altText: "" },
+            },
+            ratings: { nodes: [{ name: "9.0" }] },
+            prices: { nodes: [{ name: "£20" }] },
+          },
+          {
+            slug: "hackney-low",
+            title: "Hackney Low",
+            featuredImage: {
+              node: { sourceUrl: "https://example.com/low.jpg", altText: "" },
+            },
+            ratings: { nodes: [{ name: "7.0" }] },
+            prices: { nodes: [{ name: "£30" }] },
+          },
+        ],
+      },
+    });
+
+    expect(html).toContain("Best Roast Dinners in Hackney");
+    expect(html).toContain("Reviews:</strong> 2");
+    expect(html).toMatch(/Average rating:<\/strong>\s*8\.0\/10/);
+    expect(html).toMatch(/Average price:<\/strong>\s*£25\.00/);
+    expect(html).toContain('href="/hackney-high"');
+    expect(html).toContain("#1");
+    expect(html).toContain("#2");
+    expect(html).toContain('href="/boroughs"');
+  });
+
+  test("omits average price when no posts have prices", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./[borough].astro");
+
+    const html = await container.renderToString(Page, {
+      props: {
+        boroughName: "No Price Borough",
+        posts: [
+          {
+            slug: "no-price",
+            title: "No Price",
+            featuredImage: {
+              node: { sourceUrl: "https://example.com/np.jpg", altText: "" },
+            },
+            ratings: { nodes: [{ name: "7.0" }] },
+          },
+        ],
+      },
+    });
+
+    expect(html).not.toContain("Average price:");
+  });
+});

--- a/src/pages/boroughs/[borough].test.ts
+++ b/src/pages/boroughs/[borough].test.ts
@@ -53,6 +53,18 @@ describe("borough detail page", () => {
         date: "2025-01-01T00:00:00.000Z",
         ratings: { nodes: [{ name: "8.0" }] },
       },
+      {
+        slug: "na-borough-1",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "N/A" }] },
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+      {
+        slug: "na-borough-2",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "n/a" }] },
+        ratings: { nodes: [{ name: "7.0" }] },
+      },
     ] as Post[]);
 
     const pageModule = await import("./[borough].astro");
@@ -65,9 +77,11 @@ describe("borough detail page", () => {
     const solo = paths.find(
       (entry) => entry.params.borough === "solo-borough"
     );
+    const naBorough = paths.find((entry) => entry.params.borough === "n-a");
 
     expect(hackney).toBeDefined();
     expect(solo).toBeUndefined();
+    expect(naBorough).toBeUndefined();
     expect(hackney?.props.boroughName).toBe("Hackney");
     expect(hackney?.props.posts.map((post) => post.slug)).toEqual([
       "hackney-high",
@@ -107,7 +121,7 @@ describe("borough detail page", () => {
 
     expect(html).toContain("Best Roast Dinners in Hackney");
     expect(html).toContain("Reviews:</strong> 2");
-    expect(html).toMatch(/Average rating:<\/strong>\s*8\.0\/10/);
+    expect(html).toMatch(/Average rating:<\/strong>\s*8\.00/);
     expect(html).toMatch(/Average price:<\/strong>\s*£25\.00/);
     expect(html).toContain('href="/hackney-high"');
     expect(html).toContain("#1");

--- a/src/pages/boroughs/[borough].test.ts
+++ b/src/pages/boroughs/[borough].test.ts
@@ -65,6 +65,19 @@ describe("borough detail page", () => {
         boroughs: { nodes: [{ name: "n/a" }] },
         ratings: { nodes: [{ name: "7.0" }] },
       },
+      {
+        slug: "camden-open",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "Camden" }] },
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+      {
+        slug: "camden-closed",
+        date: "2025-01-01T00:00:00.000Z",
+        boroughs: { nodes: [{ name: "Camden" }] },
+        ratings: { nodes: [{ name: "9.0" }] },
+        closedDowns: { nodes: [{ name: "closeddown" }] },
+      },
     ] as Post[]);
 
     const pageModule = await import("./[borough].astro");
@@ -78,10 +91,12 @@ describe("borough detail page", () => {
       (entry) => entry.params.borough === "solo-borough"
     );
     const naBorough = paths.find((entry) => entry.params.borough === "n-a");
+    const camden = paths.find((entry) => entry.params.borough === "camden");
 
     expect(hackney).toBeDefined();
     expect(solo).toBeUndefined();
     expect(naBorough).toBeUndefined();
+    expect(camden).toBeUndefined();
     expect(hackney?.props.boroughName).toBe("Hackney");
     expect(hackney?.props.posts.map((post) => post.slug)).toEqual([
       "hackney-high",

--- a/src/pages/boroughs/index.astro
+++ b/src/pages/boroughs/index.astro
@@ -80,15 +80,15 @@ const boroughStats: BoroughStat[] = [...postsByBorough.entries()]
   pageTitle="Best Roast Dinners by Borough | Roast Dinners in London"
   description={`Browse ${boroughStats.length} London boroughs Lord Gravy has reviewed roast dinners in — ranked list, average rating and average price for each.`}
 >
-  <div class="boroughs-hub">
-    <FeaturedPostHeader imageSrc={logo3.src} title="Best Roast Dinners by Borough">
-      <p slot="meta" class="borough-hub-intro">
-        Every London borough Lord Gravy has reviewed a roast dinner in, with
-        average rating and average price. Boroughs with two or more reviews
-        get their own ranked page.
-      </p>
-    </FeaturedPostHeader>
+  <FeaturedPostHeader imageSrc={logo3.src} title="Best Roast Dinners by Borough">
+    <p slot="meta" class="borough-hub-intro">
+      Every London borough Lord Gravy has reviewed a roast dinner in, with
+      average rating and average price. Boroughs with two or more reviews
+      get their own ranked page.
+    </p>
+  </FeaturedPostHeader>
 
+  <div class="container boroughs-hub">
     {
       boroughStats.length > 0 && (
         <div class="boroughs-sort-controls">

--- a/src/pages/boroughs/index.astro
+++ b/src/pages/boroughs/index.astro
@@ -35,7 +35,7 @@ const postsByBorough = new Map<string, Post[]>();
 
 allPosts.forEach((post) => {
   const boroughName = post.boroughs?.nodes?.[0]?.name;
-  if (!boroughName) return;
+  if (!boroughName || boroughName.trim().toLowerCase() === "n/a") return;
 
   const current = postsByBorough.get(boroughName) ?? [];
   current.push(post);
@@ -49,7 +49,7 @@ const boroughStats: BoroughStat[] = [...postsByBorough.entries()]
       ratings.length > 0
         ? Number.parseFloat(
             (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(
-              1
+              2
             )
           )
         : null;
@@ -138,7 +138,7 @@ const boroughStats: BoroughStat[] = [...postsByBorough.entries()]
               <td>{borough.count}</td>
               <td>
                 {borough.averageRating !== null
-                  ? `${borough.averageRating.toFixed(1)}/10`
+                  ? borough.averageRating.toFixed(2)
                   : "N/A"}
               </td>
               <td>

--- a/src/pages/boroughs/index.astro
+++ b/src/pages/boroughs/index.astro
@@ -1,0 +1,209 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
+import { toOwnerSlug } from "../../lib/ownerSlug";
+import { getPostRating } from "../../lib/utils";
+import "../../styles/boroughs.css";
+import type { Post } from "../../types";
+
+export const prerender = true;
+
+const MIN_POSTS_FOR_PAGE = 2;
+
+type BoroughStat = {
+  name: string;
+  slug: string;
+  count: number;
+  averageRating: number | null;
+  averagePrice: number | null;
+  hasPage: boolean;
+};
+
+const parsePrice = (priceStr: string | undefined): number | null => {
+  if (!priceStr) return null;
+  const match = priceStr.match(/[\d,.]+/);
+  if (!match) return null;
+  const price = Number.parseFloat(match[0].replace(",", ""));
+  return !Number.isNaN(price) && price > 0 ? price : null;
+};
+
+const allPosts = await getAllRoastDinnerPosts();
+const postsByBorough = new Map<string, Post[]>();
+
+allPosts.forEach((post) => {
+  const boroughName = post.boroughs?.nodes?.[0]?.name;
+  if (!boroughName) return;
+
+  const current = postsByBorough.get(boroughName) ?? [];
+  current.push(post);
+  postsByBorough.set(boroughName, current);
+});
+
+const boroughStats: BoroughStat[] = [...postsByBorough.entries()]
+  .map(([name, posts]) => {
+    const ratings = posts.map(getPostRating).filter((r) => r > 0);
+    const averageRating =
+      ratings.length > 0
+        ? Number.parseFloat(
+            (ratings.reduce((sum, r) => sum + r, 0) / ratings.length).toFixed(
+              1
+            )
+          )
+        : null;
+
+    const prices = posts
+      .map((p) => parsePrice(p.prices?.nodes?.[0]?.name))
+      .filter((p): p is number => p !== null);
+    const averagePrice =
+      prices.length > 0
+        ? Number.parseFloat(
+            (prices.reduce((sum, p) => sum + p, 0) / prices.length).toFixed(2)
+          )
+        : null;
+
+    return {
+      name,
+      slug: toOwnerSlug(name),
+      count: posts.length,
+      averageRating,
+      averagePrice,
+      hasPage: posts.length >= MIN_POSTS_FOR_PAGE,
+    };
+  })
+  .sort((a, b) => b.count - a.count);
+---
+
+<BaseLayout
+  pageTitle="Best Roast Dinners by Borough | Roast Dinners in London"
+  description={`Browse ${boroughStats.length} London boroughs Lord Gravy has reviewed roast dinners in — ranked list, average rating and average price for each.`}
+>
+  <div class="no-image-container boroughs-hub">
+    <section class="post-title centre-with-padding">
+      <h2>Best Roast Dinners by Borough</h2>
+      <p class="borough-hub-intro">
+        Every London borough Lord Gravy has reviewed a roast dinner in, with
+        average rating and average price. Boroughs with two or more reviews
+        get their own ranked page.
+      </p>
+    </section>
+
+    {
+      boroughStats.length > 0 && (
+        <div class="boroughs-sort-controls">
+          <div class="sort-group">
+            <label for="sort-field">Sort by:</label>
+            <select id="sort-field">
+              <option value="count">Reviews</option>
+              <option value="rating">Rating</option>
+              <option value="name">Name</option>
+            </select>
+          </div>
+          <div class="sort-group">
+            <label for="sort-direction">Order:</label>
+            <select id="sort-direction">
+              <option value="desc">Descending</option>
+              <option value="asc">Ascending</option>
+            </select>
+          </div>
+        </div>
+      )
+    }
+
+    <table class="boroughs-table" id="boroughs-table">
+      <thead>
+        <tr>
+          <th>Borough</th>
+          <th>Reviews</th>
+          <th>Avg rating</th>
+          <th>Avg price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          boroughStats.map((borough) => (
+            <tr
+              data-name={borough.name}
+              data-count={borough.count}
+              data-rating={borough.averageRating ?? ""}
+            >
+              <td>
+                {borough.hasPage ? (
+                  <a href={`/boroughs/${borough.slug}`}>{borough.name}</a>
+                ) : (
+                  borough.name
+                )}
+              </td>
+              <td>{borough.count}</td>
+              <td>
+                {borough.averageRating !== null
+                  ? `${borough.averageRating.toFixed(1)}/10`
+                  : "N/A"}
+              </td>
+              <td>
+                {borough.averagePrice !== null
+                  ? `£${borough.averagePrice.toFixed(2)}`
+                  : "N/A"}
+              </td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+</BaseLayout>
+
+<script>
+  const tbody = document.querySelector("#boroughs-table tbody");
+  const fieldSelect = document.getElementById("sort-field");
+  const directionSelect = document.getElementById("sort-direction");
+
+  if (
+    tbody &&
+    fieldSelect instanceof HTMLSelectElement &&
+    directionSelect instanceof HTMLSelectElement
+  ) {
+    const sortRows = () => {
+      const field = fieldSelect.value;
+      const direction = directionSelect.value;
+      const rows = [...tbody.querySelectorAll("tr")];
+
+      rows.sort((a, b) => {
+        let aVal: number | string;
+        let bVal: number | string;
+
+        if (field === "rating") {
+          const aRating = Number.parseFloat(a.dataset.rating ?? "");
+          const bRating = Number.parseFloat(b.dataset.rating ?? "");
+          aVal = Number.isNaN(aRating)
+            ? direction === "desc"
+              ? -Infinity
+              : Infinity
+            : aRating;
+          bVal = Number.isNaN(bRating)
+            ? direction === "desc"
+              ? -Infinity
+              : Infinity
+            : bRating;
+        } else if (field === "name") {
+          aVal = a.dataset.name ?? "";
+          bVal = b.dataset.name ?? "";
+          return direction === "desc"
+            ? bVal.localeCompare(aVal)
+            : aVal.localeCompare(bVal);
+        } else {
+          aVal = Number.parseFloat(a.dataset.count ?? "0");
+          bVal = Number.parseFloat(b.dataset.count ?? "0");
+        }
+
+        return direction === "desc"
+          ? (bVal as number) - (aVal as number)
+          : (aVal as number) - (bVal as number);
+      });
+
+      rows.forEach((row) => tbody.appendChild(row));
+    };
+
+    fieldSelect.addEventListener("change", sortRows);
+    directionSelect.addEventListener("change", sortRows);
+  }
+</script>

--- a/src/pages/boroughs/index.astro
+++ b/src/pages/boroughs/index.astro
@@ -4,7 +4,7 @@ import logo3 from "../../images/logo-3.png";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
-import { getPostRating } from "../../lib/utils";
+import { getPostRating, isClosedDownPost } from "../../lib/utils";
 import "../../styles/post.css";
 import "../../styles/boroughs.css";
 import type { Post } from "../../types";
@@ -35,7 +35,12 @@ const postsByBorough = new Map<string, Post[]>();
 
 allPosts.forEach((post) => {
   const boroughName = post.boroughs?.nodes?.[0]?.name;
-  if (!boroughName || boroughName.trim().toLowerCase() === "n/a") return;
+  if (
+    !boroughName ||
+    boroughName.trim().toLowerCase() === "n/a" ||
+    isClosedDownPost(post)
+  )
+    return;
 
   const current = postsByBorough.get(boroughName) ?? [];
   current.push(post);

--- a/src/pages/boroughs/index.astro
+++ b/src/pages/boroughs/index.astro
@@ -1,8 +1,11 @@
 ---
+import FeaturedPostHeader from "../../components/featured-post-header/featured-post-header.astro";
+import logo3 from "../../images/logo-3.png";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
 import { toOwnerSlug } from "../../lib/ownerSlug";
 import { getPostRating } from "../../lib/utils";
+import "../../styles/post.css";
 import "../../styles/boroughs.css";
 import type { Post } from "../../types";
 
@@ -77,15 +80,14 @@ const boroughStats: BoroughStat[] = [...postsByBorough.entries()]
   pageTitle="Best Roast Dinners by Borough | Roast Dinners in London"
   description={`Browse ${boroughStats.length} London boroughs Lord Gravy has reviewed roast dinners in — ranked list, average rating and average price for each.`}
 >
-  <div class="no-image-container boroughs-hub">
-    <section class="post-title centre-with-padding">
-      <h2>Best Roast Dinners by Borough</h2>
-      <p class="borough-hub-intro">
+  <div class="boroughs-hub">
+    <FeaturedPostHeader imageSrc={logo3.src} title="Best Roast Dinners by Borough">
+      <p slot="meta" class="borough-hub-intro">
         Every London borough Lord Gravy has reviewed a roast dinner in, with
         average rating and average price. Boroughs with two or more reviews
         get their own ranked page.
       </p>
-    </section>
+    </FeaturedPostHeader>
 
     {
       boroughStats.length > 0 && (

--- a/src/pages/boroughs/index.test.ts
+++ b/src/pages/boroughs/index.test.ts
@@ -1,0 +1,96 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAllRoastDinnerPosts } from "../../lib/getAllRoastDinnerPosts";
+import type { Post } from "../../types";
+
+vi.mock("../../components/header/HeaderAuth");
+
+vi.mock("../../lib/getAllRoastDinnerPosts", () => ({
+  getAllRoastDinnerPosts: vi.fn(),
+}));
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  ),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.mocked(getAllRoastDinnerPosts).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("boroughs hub page", () => {
+  test("renders every borough with review count, average rating, and average price", async () => {
+    vi.mocked(getAllRoastDinnerPosts).mockResolvedValue([
+      {
+        slug: "hackney-1",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "8.0" }] },
+        prices: { nodes: [{ name: "£20" }] },
+      },
+      {
+        slug: "hackney-2",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "6.0" }] },
+        prices: { nodes: [{ name: "£30" }] },
+      },
+      {
+        slug: "solo-borough",
+        boroughs: { nodes: [{ name: "Solo Borough" }] },
+        ratings: { nodes: [{ name: "9.0" }] },
+      },
+      {
+        slug: "no-borough",
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+    ] as Post[]);
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./index.astro");
+
+    const html = await container.renderToString(Page, {});
+
+    expect(html).toContain("Best Roast Dinners by Borough");
+    expect(html).toContain('href="/boroughs/hackney"');
+    expect(html).toMatch(/Hackney[\s\S]*?2[\s\S]*?7\.0\/10[\s\S]*?£25\.00/);
+    expect(html).toContain("Solo Borough");
+    expect(html).not.toContain('href="/boroughs/solo-borough"');
+  });
+
+  test("renders sort controls when boroughs are present", async () => {
+    vi.mocked(getAllRoastDinnerPosts).mockResolvedValue([
+      {
+        slug: "hackney-1",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "8.0" }] },
+      },
+    ] as Post[]);
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./index.astro");
+
+    const html = await container.renderToString(Page, {});
+
+    expect(html).toContain('id="sort-field"');
+    expect(html).toContain('id="sort-direction"');
+  });
+
+  test("does not render sort controls when there are no boroughs", async () => {
+    vi.mocked(getAllRoastDinnerPosts).mockResolvedValue([]);
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./index.astro");
+
+    const html = await container.renderToString(Page, {});
+
+    expect(html).not.toContain('id="sort-field"');
+  });
+});

--- a/src/pages/boroughs/index.test.ts
+++ b/src/pages/boroughs/index.test.ts
@@ -51,6 +51,11 @@ describe("boroughs hub page", () => {
         slug: "no-borough",
         ratings: { nodes: [{ name: "8.0" }] },
       },
+      {
+        slug: "na-borough",
+        boroughs: { nodes: [{ name: "N/A" }] },
+        ratings: { nodes: [{ name: "5.0" }] },
+      },
     ] as Post[]);
 
     const container = await AstroContainer.create();
@@ -60,9 +65,10 @@ describe("boroughs hub page", () => {
 
     expect(html).toContain("Best Roast Dinners by Borough");
     expect(html).toContain('href="/boroughs/hackney"');
-    expect(html).toMatch(/Hackney[\s\S]*?2[\s\S]*?7\.0\/10[\s\S]*?£25\.00/);
+    expect(html).toMatch(/Hackney[\s\S]*?2[\s\S]*?7\.00[\s\S]*?£25\.00/);
     expect(html).toContain("Solo Borough");
     expect(html).not.toContain('href="/boroughs/solo-borough"');
+    expect(html).not.toMatch(/data-name="N\/A"/i);
   });
 
   test("renders sort controls when boroughs are present", async () => {

--- a/src/pages/boroughs/index.test.ts
+++ b/src/pages/boroughs/index.test.ts
@@ -56,6 +56,13 @@ describe("boroughs hub page", () => {
         boroughs: { nodes: [{ name: "N/A" }] },
         ratings: { nodes: [{ name: "5.0" }] },
       },
+      {
+        slug: "hackney-closed",
+        boroughs: { nodes: [{ name: "Hackney" }] },
+        ratings: { nodes: [{ name: "1.0" }] },
+        prices: { nodes: [{ name: "£1" }] },
+        closedDowns: { nodes: [{ name: "closeddown" }] },
+      },
     ] as Post[]);
 
     const container = await AstroContainer.create();

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -1,8 +1,8 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { toOwnerSlug } from "../lib/ownerSlug";
 import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
-import { toOwnerSlug } from "../lib/ownerSlug";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
+import { toOwnerSlug } from "../lib/ownerSlug";
 import type { Post, PostsConnection } from "../types";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";
@@ -78,15 +79,19 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
       {
         districtStats.map((district) => (
           <li>
-            The average rating in {district.name} is{" "}
-            {district.average.toFixed(2)} ({district.count} reviews)
+            The average rating in{" "}
+            <a href={`/boroughs/${toOwnerSlug(district.name)}`}>
+              {district.name}
+            </a>{" "}
+            is {district.average.toFixed(2)} ({district.count} reviews)
           </li>
         ))
       }
     </ul>
     <p>
       Do note that I am only including boroughs where I've had 3 roast dinners
-      or more.
+      or more. See the <a href="/boroughs">full borough hub</a> for every
+      borough reviewed.
     </p>
     <Newsletter />
 

--- a/src/pages/which-borough-has-the-best-roast-dinners-in-london.test.ts
+++ b/src/pages/which-borough-has-the-best-roast-dinners-in-london.test.ts
@@ -85,8 +85,13 @@ describe("which-borough-has-the-best-roast-dinners-in-london page", () => {
     expect(fetchGraphQLMock).toHaveBeenNthCalledWith(2, expect.anything(), { after: "cursor-1" });
 
     expect(html).toContain("Which Borough Has The Best Roast Dinners In London?");
-    expect(html).toMatch(/The average rating in\s+Hackney\s+is\s+8\.50\s*\(3\s+reviews\)/);
-    expect(html).toMatch(/The average rating in\s+Westminster\s+is\s+7\.50\s*\(3\s+reviews\)/);
+    expect(html).toMatch(
+      /The average rating in\s+<a href="\/boroughs\/hackney">\s*Hackney\s*<\/a>\s+is\s+8\.50\s*\(3\s+reviews\)/
+    );
+    expect(html).toMatch(
+      /The average rating in\s+<a href="\/boroughs\/westminster">\s*Westminster\s*<\/a>\s+is\s+7\.50\s*\(3\s+reviews\)/
+    );
+    expect(html).toContain('href="/boroughs"');
     expect(html).not.toContain("Camden");
     expect(html).not.toContain("Ignored Missing Rating");
     expect(html).not.toContain("Ignored Bad Rating");

--- a/src/styles/boroughs.css
+++ b/src/styles/boroughs.css
@@ -1,0 +1,68 @@
+.boroughs-hub {
+  .borough-hub-intro {
+    margin-bottom: 1.5rem;
+  }
+
+  .boroughs-sort-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0 1rem 1rem;
+  }
+
+  .sort-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .boroughs-sort-controls select {
+    width: 140px;
+  }
+
+  .boroughs-table {
+    margin-top: 1rem;
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--roast-main-text);
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.5rem;
+    }
+
+    thead th {
+      border-bottom: 1px solid var(--border-color, #ccc);
+    }
+
+    th {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    a {
+      text-decoration: underline;
+      color: var(--roast-main-text);
+    }
+  }
+}
+
+.borough-detail {
+  .borough-summary {
+    margin-bottom: 1.5rem;
+  }
+
+  .borough-back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+  }
+
+  .borough-rank {
+    color: var(--text-muted, var(--roast-main-text));
+    font-weight: normal;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/pages/boroughs/[borough].astro`, a dynamic `getStaticPaths()` route that auto-generates a ranked landing page (avg rating, avg price, link to hub) for every borough with 2+ reviews — no more manually-authored pages needed for new boroughs.
- Adds `src/pages/boroughs/index.astro`, a hub page listing every borough with review count, avg rating, and avg price, sortable by reviews/rating/name, linking through to each borough's page.
- Links the new hub from `best-roast-lists.astro` and `which-borough-has-the-best-roast-dinners-in-london.astro` (borough names there now link to their page), per the issue's discoverability requirement.
- New `src/styles/boroughs.css` (no inline `<style>` blocks).

Closes #494.

## Test plan
- [x] `yarn test` — 431/431 passing, including new `boroughs/[borough].test.ts` and `boroughs/index.test.ts`
- [x] `yarn lint` — no new issues introduced
- [x] `yarn ts-check` — 0 errors
- [x] Verified `getStaticPaths` groups posts by borough correctly, excludes boroughs with <2 reviews from static generation, and sorts by rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
