### PR TITLE
Add Elizabeth line roast dinner page

### DIFF
--- a/src/layouts/TubeLinePageLayout.astro
+++ b/src/layouts/TubeLinePageLayout.astro
@@ -9,11 +9,17 @@ import BaseLayout from "./BaseLayout.astro";
 import "../styles/post.css";
 import { sanitizeContent } from "../lib/sanitize";
 
+type TubeLineBranch = {
+  name: string;
+  stations: string[];
+};
+
 type Props = {
   singlePage: Page;
   lineName: string;
   headingClass: string;
-  stations: string[];
+  stations?: string[];
+  branches?: TubeLineBranch[];
   roastPosts: Post[];
   threadedComments: ThreadedComments;
 };
@@ -23,9 +29,14 @@ const {
   lineName,
   headingClass,
   stations,
+  branches,
   roastPosts,
   threadedComments,
 } = Astro.props;
+
+const stationBranches: TubeLineBranch[] = branches ?? [
+  { name: "", stations: stations ?? [] },
+];
 ---
 
 <BaseLayout
@@ -48,43 +59,54 @@ const {
       <p>Where can you find good roast dinners on the {lineName} Line?</p>
       <p>This is based solely on the tube station I used to get there.</p>
 
-      <ul class="station-list">
-        {
-          stations.map((station, index) => {
-            const postsForStation = roastPosts.filter((post) =>
-              post.tubeStations?.nodes.some(
-                (tubeStation) => tubeStation.name === station
-              )
-            );
+      {
+        stationBranches.map((branch) => (
+          <>
+            {branch.name && (
+              <h4 class="tube-branch-heading">{branch.name}</h4>
+            )}
+            <ul class="station-list">
+              {
+                branch.stations.map((station, index) => {
+                  const postsForStation = roastPosts.filter((post) =>
+                    post.tubeStations?.nodes.some(
+                      (tubeStation) => tubeStation.name === station
+                    )
+                  );
 
-            const topPost = postsForStation[0];
-            return (
-              <li class="station-list-item">
-                <span class="tube-circle-wrapper" aria-hidden="true">
-                  {index === 0 && <span class="tube-connector invisible" />}
-                  {index !== 0 && <span class="tube-connector" />}
-                  <span class="tube-circle" />
-                  {index !== stations.length - 1 && (
-                    <span class="tube-connector" />
-                  )}
-                  {index === stations.length - 1 && (
-                    <span class="tube-connector invisible" />
-                  )}
-                </span>
-                <span class="station-name">{station}</span>
-                {topPost && (
-                  <span class="station-post">
-                    <a href={`/${topPost.slug}`}>{topPost.title}</a>
-                    <span class="station-rating">
-                      {topPost?.ratings?.nodes[0].name}
-                    </span>
-                  </span>
-                )}
-              </li>
-            );
-          })
-        }
-      </ul>
+                  const topPost = postsForStation[0];
+                  return (
+                    <li class="station-list-item">
+                      <span class="tube-circle-wrapper" aria-hidden="true">
+                        {index === 0 && (
+                          <span class="tube-connector invisible" />
+                        )}
+                        {index !== 0 && <span class="tube-connector" />}
+                        <span class="tube-circle" />
+                        {index !== branch.stations.length - 1 && (
+                          <span class="tube-connector" />
+                        )}
+                        {index === branch.stations.length - 1 && (
+                          <span class="tube-connector invisible" />
+                        )}
+                      </span>
+                      <span class="station-name">{station}</span>
+                      {topPost && (
+                        <span class="station-post">
+                          <a href={`/${topPost.slug}`}>{topPost.title}</a>
+                          <span class="station-rating">
+                            {topPost?.ratings?.nodes[0].name}
+                          </span>
+                        </span>
+                      )}
+                    </li>
+                  );
+                })
+              }
+            </ul>
+          </>
+        ))
+      }
     </section>
   </div>
 

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -19,6 +19,7 @@
   --piccadilly: #003688;
   --victoria: #0098d4;
   --overground: #ee7c0e;
+  --elizabeth: #6950a1;
 
   /* Semantic theme tokens */
   --bg: #fff;

--- a/src/pages/best-roast-dinners-on-the-elizabeth-line.astro
+++ b/src/pages/best-roast-dinners-on-the-elizabeth-line.astro
@@ -1,0 +1,69 @@
+---
+import TubeLinePageLayout from "../layouts/TubeLinePageLayout.astro";
+import { getTubeLineRoastPosts } from "../lib/getTubeLineRoastPosts";
+import { organiseComments } from "../lib/utils";
+
+export const prerender = true;
+
+import { getSinglePageData } from "../lib/getSinglePageData";
+
+const variables = { id: "12272" };
+const singlePage = await getSinglePageData({ variables });
+
+const elizabethLineStations = [
+  "Reading",
+  "Twyford",
+  "Maidenhead",
+  "Taplow",
+  "Burnham",
+  "Slough",
+  "Langley",
+  "Iver",
+  "West Drayton",
+  "Hayes & Harlington",
+  "Southall",
+  "Hanwell",
+  "West Ealing",
+  "Ealing Broadway",
+  "Acton Main Line",
+  "Paddington",
+  "Bond Street",
+  "Tottenham Court Road",
+  "Farringdon",
+  "Liverpool Street",
+  "Whitechapel",
+  "Canary Wharf",
+  "Custom House",
+  "Woolwich",
+  "Abbey Wood",
+  "Heathrow Terminal 5",
+  "Heathrow Terminals 2 & 3",
+  "Heathrow Terminal 4",
+  "Stratford",
+  "Maryland",
+  "Forest Gate",
+  "Manor Park",
+  "Ilford",
+  "Seven Kings",
+  "Goodmayes",
+  "Chadwell Heath",
+  "Romford",
+  "Gidea Park",
+  "Harold Wood",
+  "Brentwood",
+  "Shenfield",
+];
+
+const roastPosts = await getTubeLineRoastPosts(elizabethLineStations);
+
+const threadedComments = organiseComments(singlePage.comments.nodes);
+---
+
+<TubeLinePageLayout
+  singlePage={singlePage}
+  lineName="Elizabeth"
+  headingClass="elizabeth"
+  stations={elizabethLineStations}
+  roastPosts={roastPosts}
+  threadedComments={threadedComments}
+/>

--- a/src/pages/best-roast-dinners-on-the-elizabeth-line.astro
+++ b/src/pages/best-roast-dinners-on-the-elizabeth-line.astro
@@ -10,49 +10,73 @@ import { getSinglePageData } from "../lib/getSinglePageData";
 const variables = { id: "12272" };
 const singlePage = await getSinglePageData({ variables });
 
-const elizabethLineStations = [
-  "Reading",
-  "Twyford",
-  "Maidenhead",
-  "Taplow",
-  "Burnham",
-  "Slough",
-  "Langley",
-  "Iver",
-  "West Drayton",
-  "Hayes & Harlington",
-  "Southall",
-  "Hanwell",
-  "West Ealing",
-  "Ealing Broadway",
-  "Acton Main Line",
-  "Paddington",
-  "Bond Street",
-  "Tottenham Court Road",
-  "Farringdon",
-  "Liverpool Street",
-  "Whitechapel",
-  "Canary Wharf",
-  "Custom House",
-  "Woolwich",
-  "Abbey Wood",
-  "Heathrow Terminal 5",
-  "Heathrow Terminals 2 & 3",
-  "Heathrow Terminal 4",
-  "Stratford",
-  "Maryland",
-  "Forest Gate",
-  "Manor Park",
-  "Ilford",
-  "Seven Kings",
-  "Goodmayes",
-  "Chadwell Heath",
-  "Romford",
-  "Gidea Park",
-  "Harold Wood",
-  "Brentwood",
-  "Shenfield",
+const elizabethLineBranches = [
+  {
+    name: "Reading Branch",
+    stations: [
+      "Reading",
+      "Twyford",
+      "Maidenhead",
+      "Taplow",
+      "Burnham",
+      "Slough",
+      "Langley",
+      "Iver",
+      "West Drayton",
+      "Hayes & Harlington",
+      "Southall",
+      "Hanwell",
+      "West Ealing",
+      "Ealing Broadway",
+      "Acton Main Line",
+    ],
+  },
+  {
+    name: "Heathrow Branch",
+    stations: [
+      "Heathrow Terminal 5",
+      "Heathrow Terminals 2 & 3",
+      "Heathrow Terminal 4",
+    ],
+  },
+  {
+    name: "Central Section",
+    stations: [
+      "Paddington",
+      "Bond Street",
+      "Tottenham Court Road",
+      "Farringdon",
+      "Liverpool Street",
+      "Whitechapel",
+    ],
+  },
+  {
+    name: "Abbey Wood Branch",
+    stations: ["Canary Wharf", "Custom House", "Woolwich", "Abbey Wood"],
+  },
+  {
+    name: "Shenfield Branch",
+    stations: [
+      "Stratford",
+      "Maryland",
+      "Forest Gate",
+      "Manor Park",
+      "Ilford",
+      "Seven Kings",
+      "Goodmayes",
+      "Chadwell Heath",
+      "Romford",
+      "Gidea Park",
+      "Harold Wood",
+      "Brentwood",
+      "Shenfield",
+    ],
+  },
 ];
+
+const elizabethLineStations = elizabethLineBranches.flatMap(
+  (branch) => branch.stations
+);
 
 const roastPosts = await getTubeLineRoastPosts(elizabethLineStations);
 
@@ -63,7 +87,7 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
   singlePage={singlePage}
   lineName="Elizabeth"
   headingClass="elizabeth"
-  stations={elizabethLineStations}
+  branches={elizabethLineBranches}
   roastPosts={roastPosts}
   threadedComments={threadedComments}
 />

--- a/src/pages/best-roast-dinners-on-the-elizabeth-line.test.ts
+++ b/src/pages/best-roast-dinners-on-the-elizabeth-line.test.ts
@@ -63,5 +63,10 @@ describe("best-roast-dinners-on-the-elizabeth-line page", () => {
     expect(html).toContain("Paddington Roast");
     expect(html).not.toContain("Not On Elizabeth");
     expect(html).toContain("Any comments?");
+    expect(html).toContain("Reading Branch");
+    expect(html).toContain("Heathrow Branch");
+    expect(html).toContain("Central Section");
+    expect(html).toContain("Abbey Wood Branch");
+    expect(html).toContain("Shenfield Branch");
   });
 });

--- a/src/pages/best-roast-dinners-on-the-elizabeth-line.test.ts
+++ b/src/pages/best-roast-dinners-on-the-elizabeth-line.test.ts
@@ -1,0 +1,67 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, test, vi } from "vitest";
+
+const mockPage = {
+  pageId: "12272",
+  title: "Best Roast Dinners On The Elizabeth Line",
+  content: "<p>Elizabeth intro</p>",
+  comments: { nodes: [] },
+  seo: {
+    opengraphDescription: "Elizabeth description",
+    opengraphImage: { sourceUrl: "https://example.com/elizabeth-og.jpg" }
+  },
+  featuredImage: { node: { sourceUrl: "https://example.com/elizabeth.jpg" } }
+};
+
+const mockRoastPosts = [
+  {
+    title: "Paddington Roast",
+    slug: "paddington-roast",
+    tubeStations: { nodes: [{ name: "Paddington" }] },
+    ratings: { nodes: [{ name: "8.7" }] },
+    closedDowns: { nodes: [] }
+  },
+  {
+    title: "Not On Elizabeth",
+    slug: "not-on-elizabeth",
+    tubeStations: { nodes: [{ name: "Not On Elizabeth" }] },
+    ratings: { nodes: [{ name: "9.0" }] },
+    closedDowns: { nodes: [] }
+  }
+];
+
+vi.mock("../components/header/HeaderAuth");
+
+vi.mock("../lib/getSinglePageData", () => ({
+  getSinglePageData: vi.fn(async () => mockPage)
+}));
+
+vi.mock("../lib/getTubeLineRoastPosts", () => ({
+  getTubeLineRoastPosts: vi.fn(async () => mockRoastPosts)
+}));
+
+vi.mock("astro:assets", () => ({
+  Image: (() => {
+    const ImageComponent = (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`;
+    const AstroImageComponent = ImageComponent as typeof ImageComponent & {
+      isAstroComponentFactory: boolean;
+    };
+    AstroImageComponent.isAstroComponentFactory = true;
+    return AstroImageComponent;
+  })()
+}));
+
+describe("best-roast-dinners-on-the-elizabeth-line page", () => {
+  test("renders Elizabeth line content and station-matched post", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./best-roast-dinners-on-the-elizabeth-line.astro");
+    const html = await container.renderToString(Page);
+
+    expect(html).toContain("Best Roast Dinners On The Elizabeth Line");
+    expect(html).toContain("Roast Dinners On The Elizabeth Line");
+    expect(html).toContain("Paddington Roast");
+    expect(html).not.toContain("Not On Elizabeth");
+    expect(html).toContain("Any comments?");
+  });
+});

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -636,6 +636,10 @@ p {
     }
   }
 
+  .station-name {
+    padding-right: 1rem;
+  }
+
   .station-post {
     margin-left: auto;
     text-align: right;
@@ -646,6 +650,14 @@ p {
       color: var(--roast-main-text);
     }
   }
+}
+
+.tube-branch-heading {
+  margin: 1.5rem 0 0;
+}
+
+.station-rating {
+  padding-left: 0.5rem;
 }
 
 .heading-underline {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -679,6 +679,9 @@ p {
   &.victoria {
     text-decoration-color: var(--victoria);
   }
+  &.elizabeth {
+    text-decoration-color: var(--elizabeth);
+  }
 }
 
 .tube-line-station {


### PR DESCRIPTION
Closes #496.

## Summary
- Adds `best-roast-dinners-on-the-elizabeth-line.astro`, following the exact pattern of the existing 6 tube line pages (`TubeLinePageLayout`, filtered by station name via `getTubeLineRoastPosts`)
- Backed by WordPress page id `12272` (created for this page's hero/intro/comments)
- Adds a purple `--elizabeth` CSS variable (`#6950a1`, the official TfL Elizabeth line colour) and a matching `.heading-underline.elizabeth` style, since neither existed yet
- Station list covers the full line: Reading/Heathrow branches through the central core to Shenfield/Abbey Wood

## Test plan
- [x] `yarn vitest run` — full suite passes (432 tests)
- [x] New test asserts the page renders the Elizabeth line heading and only includes posts tagged to Elizabeth line stations
