### PR TITLE
feat: add visual chart to roast dinner price inflation page

### DIFF
--- a/src/pages/roast-dinner-inflation.astro
+++ b/src/pages/roast-dinner-inflation.astro
@@ -62,16 +62,23 @@ for (const post of roastPricePosts) {
   yearStats.get(year).push(cleanedPrice);
 }
 
-const averagePrices = [...yearStats.entries()].map(([year, prices]) => {
-  const average =
-    prices.reduce((sum: number, price: string) => sum + price, 0) /
-    prices.length;
-  return {
-    year,
-    average: average.toFixed(2),
-    count: prices.length,
-  };
-});
+const averagePrices = [...yearStats.entries()]
+  .map(([year, prices]) => {
+    const average =
+      prices.reduce((sum: number, price: string) => sum + price, 0) /
+      prices.length;
+    return {
+      year,
+      average: average.toFixed(2),
+      count: prices.length,
+    };
+  })
+  .sort((a, b) => Number.parseInt(a.year, 10) - Number.parseInt(b.year, 10));
+
+const maxAveragePrice = Math.max(
+  ...averagePrices.map(({ average }) => Number.parseFloat(average)),
+  0,
+);
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
 ---
@@ -88,15 +95,19 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
   <div class="container">
     <div set:html={sanitizeContent(singlePage.content)} />
 
-    <ul>
+    <ul class="price-chart" aria-label="Average roast dinner price by year">
       {
-        averagePrices
-          .sort((a, b) => parseInt(a.year) - parseInt(b.year))
-          .map(({ year, average, count }) => (
-            <li>
-              The average price in {year} is £{average} ({count} reviews)
-            </li>
-          ))
+        averagePrices.map(({ year, average, count }) => (
+          <li class="price-chart-row">
+            <div class="bar-track" role="presentation" aria-hidden="true">
+              <div
+                class="bar-fill"
+                style={`width: ${maxAveragePrice > 0 ? Math.round((Number.parseFloat(average) / maxAveragePrice) * 100) : 0}%`}
+              />
+            </div>
+            The average price in {year} is £{average} ({count} reviews)
+          </li>
+        ))
       }
     </ul>
 
@@ -108,3 +119,35 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     <Comments threadedComments={threadedComments} postId={singlePage.pageId} />
   </div>
 </BaseLayout>
+
+<style>
+  .price-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 1.5rem 0;
+    padding: 0;
+  }
+
+  .price-chart-row {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .bar-track {
+    background: #e5e7eb;
+    border-radius: 4px;
+    height: 0.75rem;
+    overflow: hidden;
+    max-width: 400px;
+  }
+
+  .bar-fill {
+    height: 100%;
+    background: var(--roast-new-blue);
+    border-radius: 4px;
+    min-width: 2px;
+  }
+</style>


### PR DESCRIPTION
## Summary

Phase 1 of #510 ("The London Roast Dinner Index — interactive charts for Roastatistics").

`/roast-dinner-inflation` currently renders average roast price per year as a plain `<ul>` of text. The issue's own "Phase 1: Price & rating trend chart (highest impact)" section calls this page out specifically as "a single-component change" and lists it as the one page whose visualization alone would satisfy the issue's success criteria ("At least one stats page (price inflation) has a visual chart replacing the text list").

This PR adds that chart, scoped narrowly to this one page. The rest of #510 (charts on the other stats pages, dual-axis price+rating chart, a `/roastatistics` hero chart) is out of scope for this PR and left for a follow-up.

## Changes

- `src/pages/roast-dinner-inflation.astro`: each year's average price row now renders behind a horizontal bar sized relative to the highest yearly average, using the same accessible inline-SVG-free bar-chart pattern already established on `/which-month-are-roast-dinners-better` (`bar-track`/`bar-fill` divs, marked `aria-hidden`/`role="presentation"` since the adjacent text already conveys the same information — no separate table fallback needed).
- No new dependency — pure CSS bars, computed at build time from data already fetched on this page.
- Supports the site's existing dark/light theme handling identically to the pre-existing month chart (uses `var(--roast-new-blue)`).
- Also fixed a pre-existing `biome` lint issue (`parseInt` → `Number.parseInt` with radix) on a line this change already touched.

## Test plan

- [x] `yarn vitest run` — 432/432 tests passing (existing page test still asserts on the same visible text content)
- [x] `yarn ts-check` — 0 errors
- [x] `npx biome check src/pages/roast-dinner-inflation.astro` — 0 errors

---
_Generated by [Claude Code](https://claude.ai/code/session_012hb7PS1wvdmbHZw7kBkcdv)_