### PR TITLE
fix: prod 500 on SSR pages (ERR_REQUIRE_ESM in sanitize-html)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,6 +38,13 @@ export default defineConfig({
   },
   vite: {
     plugins: [clerkVirtualConfig],
+    ssr: {
+      // sanitize-html's nested htmlparser2 dependency ships ESM-only with no
+      // CJS build; left external it breaks Node's require() on Vercel at
+      // request time (ERR_REQUIRE_ESM). Bundling it lets Vite/Rollup resolve
+      // the ESM/CJS interop instead.
+      noExternal: ["sanitize-html", "htmlparser2"],
+    },
     ...(isTesting && { server: { hmr: { overlay: false } } }),
   },
   integrations: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,13 +38,6 @@ export default defineConfig({
   },
   vite: {
     plugins: [clerkVirtualConfig],
-    ssr: {
-      // sanitize-html's nested htmlparser2 dependency ships ESM-only with no
-      // CJS build; left external it breaks Node's require() on Vercel at
-      // request time (ERR_REQUIRE_ESM). Bundling it lets Vite/Rollup resolve
-      // the ESM/CJS interop instead.
-      noExternal: ["sanitize-html", "htmlparser2"],
-    },
     ...(isTesting && { server: { hmr: { overlay: false } } }),
   },
   integrations: [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "resolutions": {
     "defu": ">=6.1.5",
     "h3": "^1.15.9",
+    "htmlparser2": "10.1.0",
     "minimatch": "^10.2.1",
     "path-to-regexp": "^8.0.0",
     "picomatch": ">=2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,24 +2826,10 @@ dom-serializer@^2.0.0:
     domhandler "^5.0.2"
     entities "^4.2.0"
 
-dom-serializer@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-3.1.1.tgz#54be70ee4fcc2da010f488165e62294798dc57d3"
-  integrity sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==
-  dependencies:
-    domelementtype "^3.0.0"
-    domhandler "^6.0.0"
-    entities "^8.0.0"
-
 domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
-
-domelementtype@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-3.0.0.tgz#e6c0a24bd39ca5eb7ea67a98d2f699497d7bcc55"
-  integrity sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==
 
 domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
@@ -2851,13 +2837,6 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
-
-domhandler@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-6.0.1.tgz#75f351a03a6e10c35e08418f9cf0d287e00797cf"
-  integrity sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==
-  dependencies:
-    domelementtype "^3.0.0"
 
 domutils@^3.0.1, domutils@^3.2.2:
   version "3.2.2"
@@ -2867,15 +2846,6 @@ domutils@^3.0.1, domutils@^3.2.2:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
-
-domutils@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-4.0.2.tgz#0c1ac1fdbe8f554a60a6f5eb143ee85630327c94"
-  integrity sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==
-  dependencies:
-    dom-serializer "^3.0.0"
-    domelementtype "^3.0.0"
-    domhandler "^6.0.0"
 
 dotenv@^16.4.7:
   version "16.6.1"
@@ -2934,11 +2904,6 @@ entities@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
-
-entities@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
-  integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 es-module-lexer@^2.0.0:
   version "2.1.0"
@@ -3546,7 +3511,7 @@ html-void-elements@^3.0.0:
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
   integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
-htmlparser2@^10.1:
+htmlparser2@10.1.0, htmlparser2@^10.1, htmlparser2@^12.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
   integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
@@ -3555,16 +3520,6 @@ htmlparser2@^10.1:
     domhandler "^5.0.3"
     domutils "^3.2.2"
     entities "^7.0.1"
-
-htmlparser2@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-12.0.0.tgz#6a679d0f57c525990f9cbad8a585b320ecc6d198"
-  integrity sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==
-  dependencies:
-    domelementtype "^3.0.0"
-    domhandler "^6.0.0"
-    domutils "^4.0.2"
-    entities "^8.0.0"
 
 http-cache-semantics@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Summary
- Fixes a prod-breaking `ERR_REQUIRE_ESM` crash on any SSR (`prerender = false`) page that renders sanitized WordPress content, e.g. `/annual-roastatistics`
- Root cause: a recent dependency update resolved `sanitize-html`'s nested `htmlparser2` to v12, which is ESM-only (no CJS build). Left external in the Vercel Node function, `sanitize-html`'s CJS code does `require("htmlparser2")` at request time, which Node can't do for an ESM-only module — crashing with the generic "This page isn't working" 500
- Fix: force `sanitize-html` and `htmlparser2` into the Vite SSR bundle via `vite.ssr.noExternal`, so Rollup resolves the ESM/CJS interop at build time instead of leaving a raw `require()` to fail at runtime

## Test plan
- [x] `yarn build` succeeds
- [x] Inspected `.vercel/output/functions/_render.func` — `htmlparser2`'s exports (`DomHandler`, `ElementType`, `DomUtils`, etc.) are now static imports in the bundled chunk, not a `createRequire()`/runtime `require("htmlparser2")` call
- [x] `yarn test` — all 456 tests pass
- [x] `yarn lint` — no new warnings introduced by this change