### PR TITLE
feat: add year-over-year comparison, streak, and rating links to annual roastatistics

### DIFF
--- a/src/pages/annual-roastatistics.astro
+++ b/src/pages/annual-roastatistics.astro
@@ -77,9 +77,16 @@ const selectedYearPosts = roastPosts.filter(
   (post) => post.yearsOfVisit?.nodes?.[0]?.name === selectedYear
 );
 
-const ratingValues = selectedYearPosts
-  .map((post) => parseFirstNumericValue(post.ratings?.nodes?.[0]?.name))
-  .filter((value): value is number => value !== null);
+const ratingEntries = selectedYearPosts
+  .map((post) => ({
+    post,
+    rating: parseFirstNumericValue(post.ratings?.nodes?.[0]?.name),
+  }))
+  .filter(
+    (entry): entry is { post: Post; rating: number } => entry.rating !== null
+  );
+
+const ratingValues = ratingEntries.map((entry) => entry.rating);
 
 const priceValues = selectedYearPosts
   .map((post) => parsePriceValue(post.prices?.nodes?.[0]?.name))
@@ -90,9 +97,18 @@ const averageRating =
     ? ratingValues.reduce((sum, value) => sum + value, 0) / ratingValues.length
     : null;
 
-const highestRating =
-  ratingValues.length > 0 ? Math.max(...ratingValues) : null;
-const lowestRating = ratingValues.length > 0 ? Math.min(...ratingValues) : null;
+const highestRatingEntry =
+  ratingEntries.length > 0
+    ? ratingEntries.reduce((best, entry) =>
+        entry.rating > best.rating ? entry : best
+      )
+    : null;
+const lowestRatingEntry =
+  ratingEntries.length > 0
+    ? ratingEntries.reduce((worst, entry) =>
+        entry.rating < worst.rating ? entry : worst
+      )
+    : null;
 
 const excellentRoasts = ratingValues.filter((value) => value >= 8).length;
 const crapRoasts = ratingValues.filter((value) => value < 6).length;
@@ -104,6 +120,100 @@ const averagePrice =
 
 const mostExpensive = priceValues.length > 0 ? Math.max(...priceValues) : null;
 const leastExpensive = priceValues.length > 0 ? Math.min(...priceValues) : null;
+
+const selectedYearIndex = years.indexOf(selectedYear);
+const previousYear =
+  selectedYearIndex >= 0 && selectedYearIndex < years.length - 1
+    ? years[selectedYearIndex + 1]
+    : null;
+
+const previousYearPosts = previousYear
+  ? roastPosts.filter(
+      (post) => post.yearsOfVisit?.nodes?.[0]?.name === previousYear
+    )
+  : [];
+
+const previousYearRatingValues = previousYearPosts
+  .map((post) => parseFirstNumericValue(post.ratings?.nodes?.[0]?.name))
+  .filter((value): value is number => value !== null);
+
+const previousYearPriceValues = previousYearPosts
+  .map((post) => parsePriceValue(post.prices?.nodes?.[0]?.name))
+  .filter((value): value is number => value !== null);
+
+const previousYearAverageRating =
+  previousYearRatingValues.length > 0
+    ? previousYearRatingValues.reduce((sum, value) => sum + value, 0) /
+      previousYearRatingValues.length
+    : null;
+
+const previousYearAveragePrice =
+  previousYearPriceValues.length > 0
+    ? previousYearPriceValues.reduce((sum, value) => sum + value, 0) /
+      previousYearPriceValues.length
+    : null;
+
+const formatYearComparison = (
+  current: number | null,
+  previous: number | null,
+  formatValue: (value: number) => string
+): string | null => {
+  if (current === null || previous === null) return null;
+  const diff = current - previous;
+  if (Math.abs(diff) < 0.005) return `unchanged vs ${previousYear}`;
+  const direction = diff > 0 ? "up" : "down";
+  return `${direction} ${formatValue(Math.abs(diff))} vs ${previousYear} (${formatValue(previous)})`;
+};
+
+const showYearComparison = selectedYearPosts.length >= 5 && previousYear !== null;
+
+const ratingComparisonText = showYearComparison
+  ? formatYearComparison(averageRating, previousYearAverageRating, (value) =>
+      value.toFixed(2)
+    )
+  : null;
+
+const priceComparisonText = showYearComparison
+  ? formatYearComparison(
+      averagePrice,
+      previousYearAveragePrice,
+      (value) => `£${value.toFixed(2)}`
+    )
+  : null;
+
+const parsePostDate = (post: Post): Date | null => {
+  if (!post.date) return null;
+  const parsed = new Date(post.date);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const datedRoastPosts = roastPosts
+  .map((post) => ({
+    post,
+    date: parsePostDate(post),
+    rating: parseFirstNumericValue(post.ratings?.nodes?.[0]?.name),
+  }))
+  .filter(
+    (entry): entry is { post: Post; date: Date; rating: number | null } =>
+      entry.date !== null
+  )
+  .sort((a, b) => b.date.getTime() - a.date.getTime());
+
+const lastGreatRoastIndex = datedRoastPosts.findIndex(
+  (entry) => entry.rating !== null && entry.rating >= 8
+);
+
+const lastGreatRoast =
+  lastGreatRoastIndex >= 0 ? datedRoastPosts[lastGreatRoastIndex] : null;
+
+const roastsSinceLastGreatRoast =
+  lastGreatRoastIndex >= 0 ? lastGreatRoastIndex : datedRoastPosts.length;
+
+const daysSinceLastGreatRoast = lastGreatRoast
+  ? Math.floor(
+      (Date.now() - lastGreatRoast.date.getTime()) / (1000 * 60 * 60 * 24)
+    )
+  : null;
 
 const areaCounts = new Map<string, number>();
 const boroughCounts = new Map<string, number>();
@@ -201,6 +311,32 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     }
 
     {
+      datedRoastPosts.length > 0 ? (
+        <section>
+          <h3>Current streak</h3>
+          {lastGreatRoast ? (
+            <p>
+              It's been {daysSinceLastGreatRoast}{" "}
+              {daysSinceLastGreatRoast === 1 ? "day" : "days"} (
+              {roastsSinceLastGreatRoast}{" "}
+              {roastsSinceLastGreatRoast === 1 ? "roast dinner" : "roast dinners"})
+              since our last 8+ rated roast dinner:{" "}
+              <a href={`/${lastGreatRoast.post.slug}`}>
+                {lastGreatRoast.post.title}
+              </a>{" "}
+              ({lastGreatRoast.rating?.toFixed(2)}).
+            </p>
+          ) : (
+            <p>
+              We've never had an 8+ rated roast dinner yet —{" "}
+              {roastsSinceLastGreatRoast} roast dinners and counting.
+            </p>
+          )}
+        </section>
+      ) : null
+    }
+
+    {
       selectedYear ? (
         <section>
           <h2>{selectedYear} overview</h2>
@@ -211,24 +347,44 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
               {averageRating !== null
                 ? averageRating.toFixed(2)
                 : "No rating data"}
+              {ratingComparisonText ? ` (${ratingComparisonText})` : null}
             </li>
             <li>
               Highest rating:{" "}
-              {highestRating !== null
-                ? highestRating.toFixed(2)
-                : "No rating data"}
+              {highestRatingEntry ? (
+                <>
+                  {highestRatingEntry.rating.toFixed(2)}{" "}
+                  (
+                  <a href={`/${highestRatingEntry.post.slug}`}>
+                    {highestRatingEntry.post.title}
+                  </a>
+                  )
+                </>
+              ) : (
+                "No rating data"
+              )}
             </li>
             <li>
               Lowest rating:{" "}
-              {lowestRating !== null
-                ? lowestRating.toFixed(2)
-                : "No rating data"}
+              {lowestRatingEntry ? (
+                <>
+                  {lowestRatingEntry.rating.toFixed(2)}{" "}
+                  (
+                  <a href={`/${lowestRatingEntry.post.slug}`}>
+                    {lowestRatingEntry.post.title}
+                  </a>
+                  )
+                </>
+              ) : (
+                "No rating data"
+              )}
             </li>
             <li>
               Average price:{" "}
               {averagePrice !== null
                 ? `£${averagePrice.toFixed(2)}`
                 : "No price data"}
+              {priceComparisonText ? ` (${priceComparisonText})` : null}
             </li>
             <li>
               Most expensive:{" "}

--- a/src/pages/annual-roastatistics.test.ts
+++ b/src/pages/annual-roastatistics.test.ts
@@ -314,4 +314,167 @@ describe("annual-roastatistics page", () => {
     expect(html).toContain("Excellent roasts: 0");
     expect(html).toContain("Crap roasts: 0");
   });
+
+  test("links highest and lowest rating to their respective reviews", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./annual-roastatistics.astro");
+    const html = await container.renderToString(Page, {
+      request: new Request("https://rdldn.co.uk/annual-roastatistics")
+    });
+
+    expect(html).toMatch(/Highest rating:[\s\S]*Lambeth Roast/);
+    expect(html).toMatch(/Lowest rating:[\s\S]*Camden Roast/);
+  });
+
+  test("shows year-over-year comparison once the selected year has 5+ roasts", async () => {
+    fetchGraphQLMock.mockImplementation(async (_query: string, variables: Record<string, unknown> = {}) => {
+      if (!variables.after) {
+        return {
+          posts: {
+            nodes: [
+              {
+                title: "2025 Roast 1",
+                slug: "2025-roast-1",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                yearsOfVisit: { nodes: [{ name: "2025" }] },
+                ratings: { nodes: [{ name: "8.0" }] },
+                prices: { nodes: [{ name: "GBP 30" }] }
+              },
+              {
+                title: "2025 Roast 2",
+                slug: "2025-roast-2",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                yearsOfVisit: { nodes: [{ name: "2025" }] },
+                ratings: { nodes: [{ name: "8.0" }] },
+                prices: { nodes: [{ name: "GBP 30" }] }
+              },
+              {
+                title: "2025 Roast 3",
+                slug: "2025-roast-3",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                yearsOfVisit: { nodes: [{ name: "2025" }] },
+                ratings: { nodes: [{ name: "8.0" }] },
+                prices: { nodes: [{ name: "GBP 30" }] }
+              },
+              {
+                title: "2025 Roast 4",
+                slug: "2025-roast-4",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                yearsOfVisit: { nodes: [{ name: "2025" }] },
+                ratings: { nodes: [{ name: "8.0" }] },
+                prices: { nodes: [{ name: "GBP 30" }] }
+              },
+              {
+                title: "2025 Roast 5",
+                slug: "2025-roast-5",
+                typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+                yearsOfVisit: { nodes: [{ name: "2025" }] },
+                ratings: { nodes: [{ name: "8.0" }] },
+                prices: { nodes: [{ name: "GBP 30" }] }
+              }
+            ],
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: "cursor-1"
+            }
+          }
+        };
+      }
+
+      return {
+        posts: {
+          nodes: [
+            {
+              title: "2024 Roast 1",
+              slug: "2024-roast-1",
+              typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+              yearsOfVisit: { nodes: [{ name: "2024" }] },
+              ratings: { nodes: [{ name: "7.0" }] },
+              prices: { nodes: [{ name: "GBP 20" }] }
+            }
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            endCursor: null
+          }
+        }
+      };
+    });
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./annual-roastatistics.astro");
+    const html = await container.renderToString(Page, {
+      request: new Request("https://rdldn.co.uk/annual-roastatistics?year=2025")
+    });
+
+    expect(html).toMatch(/Average rating:\s*8\.00\s*\(up 1\.00 vs 2024 \(7\.00\)\)/);
+    expect(html).toMatch(/Average price:\s*£\s*30\.00\s*\(up £10\.00 vs 2024 \(£20\.00\)\)/);
+  });
+
+  test("hides year-over-year comparison when the selected year has fewer than 5 roasts", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./annual-roastatistics.astro");
+    const html = await container.renderToString(Page, {
+      request: new Request("https://rdldn.co.uk/annual-roastatistics?year=2024")
+    });
+
+    expect(html).not.toContain("vs 2023");
+    expect(html).toMatch(/Average rating:\s*9\.00\s*<\/li>/);
+  });
+
+  test("shows the current streak since the last 8+ rated roast dinner", async () => {
+    const now = Date.now();
+    const fiveDaysAgo = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const twentyDaysAgo = new Date(now - 20 * 24 * 60 * 60 * 1000).toISOString();
+
+    fetchGraphQLMock.mockResolvedValue({
+      posts: {
+        nodes: [
+          {
+            title: "Recent Decent Roast",
+            slug: "recent-decent-roast",
+            date: fiveDaysAgo,
+            typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+            yearsOfVisit: { nodes: [{ name: "2026" }] },
+            ratings: { nodes: [{ name: "7.0" }] },
+            prices: { nodes: [{ name: "GBP 20" }] }
+          },
+          {
+            title: "Great Roast",
+            slug: "great-roast",
+            date: tenDaysAgo,
+            typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+            yearsOfVisit: { nodes: [{ name: "2026" }] },
+            ratings: { nodes: [{ name: "9.0" }] },
+            prices: { nodes: [{ name: "GBP 25" }] }
+          },
+          {
+            title: "Old Roast",
+            slug: "old-roast",
+            date: twentyDaysAgo,
+            typesOfPost: { nodes: [{ name: "Roast Dinner" }] },
+            yearsOfVisit: { nodes: [{ name: "2026" }] },
+            ratings: { nodes: [{ name: "6.0" }] },
+            prices: { nodes: [{ name: "GBP 15" }] }
+          }
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: null
+        }
+      }
+    });
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./annual-roastatistics.astro");
+    const html = await container.renderToString(Page, {
+      request: new Request("https://rdldn.co.uk/annual-roastatistics")
+    });
+
+    expect(html).toContain("Current streak");
+    expect(html).toMatch(/It's been 10 days \(1 roast dinner\)/);
+    expect(html).toMatch(/great-roast/);
+    expect(html).toContain("Great Roast");
+  });
 });


### PR DESCRIPTION
## Summary

Adds three enhancements to the `annual-roastatistics` page (`src/pages/annual-roastatistics.astro`):

- **Year-over-year comparison**: once the selected year has 5+ reviewed roasts, average rating and average price are shown alongside how they compare to the previous year with data (e.g. "up 0.30 vs 2023 (7.20)").
- **Current streak**: a new "Current streak" section shows how many days (and roast dinners) it's been since the last 8+ rated roast dinner, across all years, linking to that review. If there's never been an 8+ rated roast, it shows a running count instead.
- **Highest/lowest rating links**: the highest and lowest rated roast dinner for the selected year now link through to their respective review pages, instead of showing a bare number.

## Test plan

- [x] `vitest run src/pages/annual-roastatistics.test.ts` — added new tests for year-over-year comparison (shown/hidden), the streak calculation, and the highest/lowest rating links; all 9 tests pass
- [x] `vitest run` (full suite) — 460 tests pass
- [x] `astro check` — 0 errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKomzKwN5Rx8zNV4Mnbekj)_