### PR TITLE
feat: add privacy policy page

### DIFF
--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -13,4 +13,6 @@ import SocialLinks from "../social-links/social-links.astro";
   </a>
 
   &copy; {today.getFullYear()} Roast Dinners In London
+
+  <a href="/privacy-policy" class="footer-link">Privacy Policy</a>
 </footer>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -16,15 +16,15 @@ const lastUpdated = "29 July 2026";
     <p>Last updated: {lastUpdated}</p>
 
     <p>
-      This policy explains what personal data Roast Dinners In London
-      ("we", "us") collects when you use this site, why we collect it, and
-      how you can control it.
+      This policy explains what personal data Roast Dinners In London ("we",
+      "us") collects when you use this site, why we collect it, and how you can
+      control it.
     </p>
 
     <h2>Who we are</h2>
     <p>
-      Roast Dinners In London is a UK-based independent review site. If you
-      have questions about this policy or your data, contact us via the
+      Roast Dinners In London is a UK-based independent review site. If you have
+      questions about this policy or your data, contact us via the{" "}
       <a href="/about">about page</a>.
     </p>
 
@@ -32,17 +32,17 @@ const lastUpdated = "29 July 2026";
 
     <h3>Account data</h3>
     <p>
-      If you sign in, authentication is handled by our provider, Clerk. When
-      you create an account we store your Clerk user ID and email address in
-      our database so we can associate your saved roasts, visits, and game
-      scores with your account.
+      If you sign in, authentication is handled by our provider, Clerk. When you
+      create an account we store your Clerk user ID and email address in our
+      database so we can associate your saved roasts, visits, and game scores
+      with your account.
     </p>
 
     <h3>Wishlist and visit history</h3>
     <p>
       When you save a roast to your wishlist or mark one as visited, we store
-      the post, your rating, and (for visits) any notes you add, linked to
-      your account, so you can see them again on
+      the post, your rating, and (for visits) any notes you add, linked to your
+      account, so you can see them again on{" "}
       <a href="/my-roasts">My Roasts</a>.
     </p>
 
@@ -55,16 +55,15 @@ const lastUpdated = "29 July 2026";
     <h3>Comments</h3>
     <p>
       If you leave a comment on a review, we collect the name, email address,
-      and comment text you submit. Comments are stored by our content
-      platform and are moderated before appearing publicly. Your email
-      address is never shown publicly.
+      and comment text you submit. Comments are stored by our content platform
+      and are moderated before appearing publicly. Your email address is never
+      shown publicly.
     </p>
 
     <h3>Newsletter</h3>
     <p>
-      If you subscribe to our newsletter, this is handled directly by
-      Substack, who will process your email address under their own privacy
-      policy.
+      If you subscribe to our newsletter, this is handled directly by Substack,
+      who will process your email address under their own privacy policy.
     </p>
 
     <h3>Analytics</h3>
@@ -76,7 +75,10 @@ const lastUpdated = "29 July 2026";
 
     <h2>Why we collect it</h2>
     <ul>
-      <li>To let you sign in and keep your wishlist, visits, and game scores saved between visits</li>
+      <li>
+        To let you sign in and keep your wishlist, visits, and game scores saved
+        between visits
+      </li>
       <li>To moderate and display comments</li>
       <li>To send newsletter updates, if you choose to subscribe</li>
       <li>To understand site usage and improve the site</li>
@@ -98,17 +100,16 @@ const lastUpdated = "29 July 2026";
 
     <h2>How long we keep it</h2>
     <p>
-      We keep account data, wishlist items, visits, and game scores for as
-      long as your account exists. Comments are kept indefinitely unless you
-      ask us to remove them, as they form part of the public discussion on a
-      review.
+      We keep account data, wishlist items, visits, and game scores for as long
+      as your account exists. Comments are kept indefinitely unless you ask us
+      to remove them, as they form part of the public discussion on a review.
     </p>
 
     <h2>Your rights</h2>
     <p>
-      Under UK GDPR you can ask us to access, correct, or delete your
-      personal data. To delete your account and associated data, or to make
-      any other request, contact us via the <a href="/about">about page</a>.
+      Under UK GDPR you can ask us to access, correct, or delete your personal
+      data. To delete your account and associated data, or to make any other
+      request, contact us via the <a href="/about">about page</a>.
     </p>
 
     <h2>Cookies</h2>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,0 +1,127 @@
+---
+export const prerender = true;
+
+import BaseLayout from "../layouts/BaseLayout.astro";
+import "../styles/index.css";
+
+const lastUpdated = "29 July 2026";
+---
+
+<BaseLayout
+  pageTitle="Privacy Policy"
+  description="How Roast Dinners In London collects, uses, and protects your data."
+>
+  <section class="container">
+    <h1>Privacy Policy</h1>
+    <p>Last updated: {lastUpdated}</p>
+
+    <p>
+      This policy explains what personal data Roast Dinners In London
+      ("we", "us") collects when you use this site, why we collect it, and
+      how you can control it.
+    </p>
+
+    <h2>Who we are</h2>
+    <p>
+      Roast Dinners In London is a UK-based independent review site. If you
+      have questions about this policy or your data, contact us via the
+      <a href="/about">about page</a>.
+    </p>
+
+    <h2>What we collect</h2>
+
+    <h3>Account data</h3>
+    <p>
+      If you sign in, authentication is handled by our provider, Clerk. When
+      you create an account we store your Clerk user ID and email address in
+      our database so we can associate your saved roasts, visits, and game
+      scores with your account.
+    </p>
+
+    <h3>Wishlist and visit history</h3>
+    <p>
+      When you save a roast to your wishlist or mark one as visited, we store
+      the post, your rating, and (for visits) any notes you add, linked to
+      your account, so you can see them again on
+      <a href="/my-roasts">My Roasts</a>.
+    </p>
+
+    <h3>Game scores</h3>
+    <p>
+      If you play Guess The Score, we store your personal best against your
+      account.
+    </p>
+
+    <h3>Comments</h3>
+    <p>
+      If you leave a comment on a review, we collect the name, email address,
+      and comment text you submit. Comments are stored by our content
+      platform and are moderated before appearing publicly. Your email
+      address is never shown publicly.
+    </p>
+
+    <h3>Newsletter</h3>
+    <p>
+      If you subscribe to our newsletter, this is handled directly by
+      Substack, who will process your email address under their own privacy
+      policy.
+    </p>
+
+    <h3>Analytics</h3>
+    <p>
+      We use Google Analytics to understand how visitors use the site (pages
+      viewed, general location, device type). This data is anonymised where
+      possible and is not linked to your account.
+    </p>
+
+    <h2>Why we collect it</h2>
+    <ul>
+      <li>To let you sign in and keep your wishlist, visits, and game scores saved between visits</li>
+      <li>To moderate and display comments</li>
+      <li>To send newsletter updates, if you choose to subscribe</li>
+      <li>To understand site usage and improve the site</li>
+    </ul>
+
+    <h2>Who we share it with</h2>
+    <p>We don't sell your data. We use the following third-party processors:</p>
+    <ul>
+      <li><strong>Clerk</strong> — authentication and account management</li>
+      <li><strong>Substack</strong> — newsletter delivery</li>
+      <li><strong>Google Analytics</strong> — site usage analytics</li>
+      <li>Our content platform — storing and moderating comments</li>
+    </ul>
+    <p>
+      Some of these providers may process data outside the UK/EEA. Where they
+      do, they provide their own safeguards (such as Standard Contractual
+      Clauses) — see each provider's own privacy policy for details.
+    </p>
+
+    <h2>How long we keep it</h2>
+    <p>
+      We keep account data, wishlist items, visits, and game scores for as
+      long as your account exists. Comments are kept indefinitely unless you
+      ask us to remove them, as they form part of the public discussion on a
+      review.
+    </p>
+
+    <h2>Your rights</h2>
+    <p>
+      Under UK GDPR you can ask us to access, correct, or delete your
+      personal data. To delete your account and associated data, or to make
+      any other request, contact us via the <a href="/about">about page</a>.
+    </p>
+
+    <h2>Cookies</h2>
+    <p>
+      We use cookies for authentication (via Clerk) and analytics (via Google
+      Analytics). You can control or delete cookies through your browser
+      settings.
+    </p>
+
+    <h2>Changes to this policy</h2>
+    <p>
+      We may update this policy from time to time. Changes will be posted on
+      this page with an updated date.
+    </p>
+  </section>
+</BaseLayout>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -3,6 +3,7 @@ export const prerender = true;
 
 import BaseLayout from "../layouts/BaseLayout.astro";
 import "../styles/index.css";
+import "../styles/privacy-policy.css";
 
 const lastUpdated = "29 July 2026";
 ---
@@ -11,7 +12,7 @@ const lastUpdated = "29 July 2026";
   pageTitle="Privacy Policy"
   description="How Roast Dinners In London collects, uses, and protects your data."
 >
-  <section class="container">
+  <section class="container privacy-policy">
     <h1>Privacy Policy</h1>
     <p>Last updated: {lastUpdated}</p>
 

--- a/src/pages/privacy-policy.test.ts
+++ b/src/pages/privacy-policy.test.ts
@@ -1,0 +1,23 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../components/header/HeaderAuth");
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  )
+}));
+
+describe("privacy policy page", () => {
+  test("renders", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./privacy-policy.astro");
+    const html = await container.renderToString(Page);
+
+    expect(html).toContain("Privacy Policy");
+    expect(html).toContain("Clerk");
+  });
+});

--- a/src/styles/privacy-policy.css
+++ b/src/styles/privacy-policy.css
@@ -1,0 +1,3 @@
+.privacy-policy {
+  margin-top: 120px;
+}


### PR DESCRIPTION
## Summary
- Add a `/privacy-policy` page covering account data (Clerk), wishlist/visits/game score storage, comments, newsletter (Substack), and Google Analytics
- Link to it from the footer

## Why
The site now collects logins (Clerk auth) and personal data, so a privacy policy is needed for UK GDPR compliance.

## Test plan
- [x] `yarn vitest run src/pages/privacy-policy.test.ts` passes
- [x] `yarn vitest run src/components/footer/footer.test.ts` passes
- [ ] Recommend a solicitor/legal review of the final wording before relying on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)