### PR TITLE
fix: allow bluesky embeds to render

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -144,14 +144,18 @@ const featuredImageUrl = (singlePost.featuredImage?.node?.sourceUrl || logo3.src
 
 const rawContent = singlePost.content?.replace(/i\d+\.wp\.com\/rdldn\.co\.uk/g, "blog.rdldn.co.uk") ?? "";
 const safeContent = sanitizeHtml(rawContent, {
-  allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "figure", "figcaption", "iframe"]),
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "figure", "figcaption", "iframe", "script"]),
   allowedAttributes: {
     ...sanitizeHtml.defaults.allowedAttributes,
     img: ["src", "srcset", "alt", "width", "height", "loading", "class"],
     iframe: ["src", "width", "height", "allowfullscreen", "frameborder", "title"],
+    script: ["src", "async", "charset"],
+    blockquote: ["data-bluesky-uri", "data-bluesky-cid", "data-bluesky-embed-color-mode"],
     "*": ["class", "id"],
   },
   allowedSchemes: ["http", "https", "mailto"],
+  allowedScriptHostnames: ["embed.bsky.app"],
+  allowVulnerableTags: true,
 });
 
 const threadedComments = organiseComments(


### PR DESCRIPTION
## Problem

Bluesky embeds in post content weren't appearing.

WordPress renders a Bluesky embed as a `<blockquote class="bluesky-embed">` plus a `<script src="https://embed.bsky.app/static/embed.js">` — the script is what converts the blockquote into an actual `<iframe>` client-side.

In `src/pages/[slug].astro`, post content is passed through `sanitize-html`, which only allowlisted `img`, `figure`, `figcaption`, and `iframe` on top of the defaults — so the `<script>` tag was stripped and the blockquote never became an iframe. A CSS rule in `src/styles/post.css` (`figure.wp-block-embed:not(:has(iframe)) { display: none; }`) then hid the whole embed since it never contained an iframe.

## Fix

Allow the `script` tag through sanitize-html, but scope it strictly to `embed.bsky.app` via `allowedScriptHostnames` so no other script sources can sneak through. Also allow the `data-bluesky-*` attributes on `blockquote` that the embed script relies on.

## Test plan

- [x] `yarn astro check` passes with no new errors
- [ ] Verify a post with a Bluesky embed renders the embed correctly in a deployed preview
