### PR TITLE
Add multi-year filter to maps page

### DIFF
--- a/src/components/roast-map/roast-map.test.tsx
+++ b/src/components/roast-map/roast-map.test.tsx
@@ -94,6 +94,14 @@ const sampleMarkers = [
   { lat: 51.52, lng: -0.12, label: "NaN Rating", rating: Number.NaN, slug: "nan-rating" }
 ];
 
+const yearMarkers = [
+  { lat: 51.51, lng: -0.1, label: "Visited 2022", rating: 9.0, slug: "visited-2022", year: "2022" },
+  { lat: 51.52, lng: -0.11, label: "Visited 2023", rating: 8.9, slug: "visited-2023", year: "2023" },
+  { lat: 51.53, lng: -0.12, label: "Visited 2024", rating: 8.8, slug: "visited-2024", year: "2024" },
+  { lat: 51.54, lng: -0.13, label: "Visited 2025", rating: 8.7, slug: "visited-2025", year: "2025" },
+  { lat: 51.55, lng: -0.14, label: "No Year", rating: 8.6, slug: "no-year" }
+];
+
 const colourBandMarkers = [
   { lat: 51.501, lng: -0.101, label: "Nine Plus", rating: 9.0, slug: "nine-plus" },
   { lat: 51.502, lng: -0.102, label: "Eight Point Five", rating: 8.5, slug: "eight-five" },
@@ -243,6 +251,70 @@ describe("roast-map component", () => {
       icon: expect.anything(),
       title: "Open One (9.2/10)",
       alt: "Open One (9.2/10)"
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("does not render a year filter when no markers have a year", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<RoastMap markers={sampleMarkers} />);
+    });
+    await waitForRender();
+
+    expect(host.querySelector("fieldset")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("shows all years by default and filters markers by one or more selected years", async () => {
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<RoastMap markers={yearMarkers} />);
+    });
+    await waitForRender();
+
+    const yearCheckboxes = Array.from(
+      host.querySelectorAll('fieldset input[type="checkbox"]')
+    ) as HTMLInputElement[];
+    expect(yearCheckboxes.map((cb) => cb.parentElement?.textContent?.trim())).toEqual([
+      "2022",
+      "2023",
+      "2024",
+      "2025"
+    ]);
+
+    let counts = host.querySelector('[data-test-id="map-marker-counts"]');
+    expect(counts?.getAttribute("data-visible-markers")).toBe("5");
+
+    const getCheckboxForYear = (year: string) =>
+      yearCheckboxes.find((cb) => cb.parentElement?.textContent?.trim() === year) as HTMLInputElement;
+
+    leafletMocks.markerMock.mockClear();
+    await act(async () => {
+      getCheckboxForYear("2022").click();
+      getCheckboxForYear("2024").click();
+    });
+    await waitForRender();
+
+    counts = host.querySelector('[data-test-id="map-marker-counts"]');
+    expect(counts?.getAttribute("data-visible-markers")).toBe("2");
+    expect(leafletMocks.markerMock).toHaveBeenCalledWith([51.51, -0.1], {
+      icon: expect.anything(),
+      title: "Visited 2022 (9.0/10)",
+      alt: "Visited 2022 (9.0/10)"
+    });
+    expect(leafletMocks.markerMock).toHaveBeenCalledWith([51.53, -0.12], {
+      icon: expect.anything(),
+      title: "Visited 2024 (8.8/10)",
+      alt: "Visited 2024 (8.8/10)"
     });
 
     await act(async () => {

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -9,6 +9,7 @@ type Marker = {
   rating: number;
   slug?: string;
   closed?: string;
+  year?: string;
 };
 
 type Props = {
@@ -57,15 +58,25 @@ export default function RoastMap({ markers }: Props) {
   const markersLayerRef = useRef<L.LayerGroup | null>(null);
   const [showClosed, setShowClosed] = useState(false);
   const [minRating, setMinRating] = useState(0);
+  const [selectedYears, setSelectedYears] = useState<string[]>([]);
+  const availableYears = useMemo(
+    () =>
+      Array.from(new Set(markers.map(({ year }) => year).filter((year): year is string => Boolean(year)))).sort(),
+    [markers]
+  );
+  const toggleYear = (year: string) => {
+    setSelectedYears((prev) => (prev.includes(year) ? prev.filter((y) => y !== year) : [...prev, year]));
+  };
   const filteredMarkers = useMemo(
     () =>
-      markers.filter(({ lat, lng, closed, rating }) => {
+      markers.filter(({ lat, lng, closed, rating, year }) => {
         if (!showClosed && closed) return false;
         if (!Number.isFinite(rating)) return false;
         if (rating < minRating) return false;
+        if (selectedYears.length > 0 && (!year || !selectedYears.includes(year))) return false;
         return Boolean(lat && lng);
       }),
-    [markers, showClosed, minRating]
+    [markers, showClosed, minRating, selectedYears]
   );
   const visibleMarkers = filteredMarkers.length;
   const closedMarkers = useMemo(
@@ -143,6 +154,19 @@ export default function RoastMap({ markers }: Props) {
         value={minRating}
         onChange={(e) => setMinRating(Number(e.target.value))}
       />
+      <br />
+      <br />
+      {availableYears.length > 0 && (
+        <fieldset>
+          <legend>Filter by year visited:</legend>
+          {availableYears.map((year) => (
+            <label key={year} style={{ marginRight: "1rem" }}>
+              <input type="checkbox" checked={selectedYears.includes(year)} onChange={() => toggleYear(year)} />
+              {year}
+            </label>
+          ))}
+        </fieldset>
+      )}
       <p aria-live="polite" className="sr-only">
         {visibleMarkers} {visibleMarkers === 1 ? "restaurant" : "restaurants"} shown on map
       </p>

--- a/src/lib/queries/getAllPostLocations.ts
+++ b/src/lib/queries/getAllPostLocations.ts
@@ -20,6 +20,11 @@ const GET_ALL_POST_LOCATIONS = `
             name
           }
         }
+        yearsOfVisit {
+          nodes {
+            name
+          }
+        }
       }
       pageInfo {
         endCursor

--- a/src/pages/maps.astro
+++ b/src/pages/maps.astro
@@ -63,6 +63,7 @@ const markers = allPosts
     rating: Number(post.ratings?.nodes[0]?.name),
     slug: post.slug,
     closed: post.closedDowns?.nodes[0]?.name || "",
+    year: post.yearsOfVisit?.nodes[0]?.name || "",
   }));
 ---
 

--- a/src/pages/maps.test.ts
+++ b/src/pages/maps.test.ts
@@ -61,7 +61,8 @@ describe("maps page", () => {
                 slug: "map-pub-one",
                 location: { latitude: "51.500", longitude: "-0.100" },
                 ratings: { nodes: [{ name: "4.8" }] },
-                closedDowns: { nodes: [] }
+                closedDowns: { nodes: [] },
+                yearsOfVisit: { nodes: [{ name: "2024" }] }
               },
               {
                 title: "Missing Latitude",
@@ -116,6 +117,7 @@ describe("maps page", () => {
     expect(html).toContain("Map Pub Two");
     expect(html).toContain("map-pub-two");
     expect(html).not.toContain("Missing Latitude");
+    expect(html).toContain("2024");
   });
 
   test("throws when single page data cannot be loaded", async () => {

--- a/tests/e2e/maps.spec.ts
+++ b/tests/e2e/maps.spec.ts
@@ -91,4 +91,30 @@ test.describe("maps page", () => {
     const filteredRendered = await getRenderedMarkerCount(page);
     expect(filteredRendered).toBe(filteredCounts.visible);
   });
+
+  test("year filter narrows visible markers and supports selecting multiple years", async ({ page }) => {
+    await page.goto("/maps");
+    await waitForMapTiles(page);
+
+    const yearFieldset = page.locator("fieldset", { hasText: "Filter by year visited" });
+    if ((await yearFieldset.count()) === 0) {
+      test.skip(true, "No markers with a year to filter by");
+    }
+
+    const initialCounts = await getMarkerCounts(page);
+
+    const yearCheckboxes = yearFieldset.locator('input[type="checkbox"]');
+    const yearCount = await yearCheckboxes.count();
+    expect(yearCount).toBeGreaterThan(0);
+
+    await yearCheckboxes.first().check();
+    const singleYearCounts = await getMarkerCounts(page);
+    expect(singleYearCounts.visible).toBeLessThanOrEqual(initialCounts.visible);
+
+    if (yearCount > 1) {
+      await yearCheckboxes.nth(1).check();
+      const twoYearCounts = await getMarkerCounts(page);
+      expect(twoYearCounts.visible).toBeGreaterThanOrEqual(singleYearCounts.visible);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add `yearsOfVisit` to the `GET_ALL_POST_LOCATIONS` GraphQL query and thread the visited year through into each map marker (`src/lib/queries/getAllPostLocations.ts`, `src/pages/maps.astro`)
- Add a "Filter by year visited" checkbox group to `RoastMap` so users can filter the map by one or more years simultaneously (e.g. select 2022, 2023, 2024 and 2025 all at once), following the existing checkbox-group UI pattern used elsewhere in the app
- Leaving all year checkboxes unselected shows all markers (matches the opt-in behaviour of the existing "show closed places" filter)

## Test plan
- [x] `vitest run` — full suite passes (463 tests), including new unit tests for the year filter in `roast-map.test.tsx` and an updated `maps.test.ts` assertion
- [x] `astro check` — no new type errors
- [x] `biome check` — no new lint issues on changed files
- [x] Added a Playwright e2e test (`tests/e2e/maps.spec.ts`) for selecting one and multiple years, skipped gracefully if no markers currently have a year set

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMx6eB3m515xpByV1TujFR)_