### PR TITLE
fix(deps): pin fast-uri and svgo resolutions to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
   },
   "resolutions": {
     "defu": ">=6.1.5",
+    "fast-uri": ">=3.1.3",
     "h3": "^1.15.9",
     "htmlparser2": "10.1.0",
     "minimatch": "^10.2.1",
     "path-to-regexp": "^8.0.0",
     "picomatch": ">=2.3.2",
     "smol-toml": ">=1.6.1",
+    "svgo": ">=4.0.2",
     "tar": "^7.5.8",
     "vite": ">=8.0.13",
     "yaml": ">=2.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,10 +3226,10 @@ fast-string-width@^3.0.2:
   dependencies:
     fast-string-truncated-width "^3.0.2"
 
-fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@>=3.1.3, fast-uri@^3.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-4.1.2.tgz#1e225af32fb0a178db8f14d7d9ba93ff24485694"
+  integrity sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"
@@ -5408,10 +5408,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svgo@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.1.tgz#c82dacd04ee9f1d55cd4e0b7f9a214c86670e3ee"
-  integrity sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==
+svgo@>=4.0.2, svgo@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.2.tgz#a62246f0a9d671c0314d04f3cc15f78b1bd0667f"
+  integrity sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==
   dependencies:
     commander "^11.1.0"
     css-select "^5.1.0"


### PR DESCRIPTION
## Summary
- `yarn audit` flagged two high-severity issues: `fast-uri` (host confusion via failed IDN canonicalization) and `svgo` (removeScripts plugin leaves some executable scripts intact)
- Added `resolutions` entries to pin `fast-uri` to `>=3.1.3` and `svgo` to `>=4.0.2`, resolving both to patched versions (4.1.2 and 4.0.2 respectively)

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn audit` no longer reports the fast-uri/svgo issues
- [x] `yarn test` — all 470 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)