### PR TITLE
Add hidden random pub picker to the to-do list page

### DIFF
--- a/src/components/random-pub-picker/random-pub-picker.css
+++ b/src/components/random-pub-picker/random-pub-picker.css
@@ -1,0 +1,32 @@
+.random-pub-picker {
+  margin: 10px 0;
+}
+
+.random-pub-picker__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: 2px solid var(--roast-new-blue);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  color: var(--roast-main-text);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: normal;
+  text-transform: none;
+  height: auto;
+  margin: 10px 0;
+  min-width: 13rem;
+  text-decoration: none;
+  justify-content: center;
+}
+
+.random-pub-picker__result {
+  margin: 10px 0;
+  font-size: 1.1rem;
+}
+
+.random-pub-picker__result strong {
+  color: var(--roast-pink);
+}

--- a/src/components/random-pub-picker/random-pub-picker.test.tsx
+++ b/src/components/random-pub-picker/random-pub-picker.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import RandomPubPicker from "./random-pub-picker";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const waitForEffects = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+const createHost = () => {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  return { host, root: createRoot(host) };
+};
+
+const setSearch = (search: string) => {
+  window.history.replaceState(null, "", search ? `?${search}` : window.location.pathname);
+};
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  setSearch("");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  setSearch("");
+});
+
+describe("RandomPubPicker", () => {
+  test("renders nothing when the query param is absent", async () => {
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<RandomPubPicker pubs={["The Marksman"]} />);
+    });
+    await waitForEffects();
+
+    expect(host.innerHTML).toBe("");
+
+    await act(async () => root.unmount());
+  });
+
+  test("renders nothing when there are no pubs, even with the query param present", async () => {
+    setSearch("randomPub");
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<RandomPubPicker pubs={[]} />);
+    });
+    await waitForEffects();
+
+    expect(host.innerHTML).toBe("");
+
+    await act(async () => root.unmount());
+  });
+
+  test("renders a button when the query param is present", async () => {
+    setSearch("randomPub");
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<RandomPubPicker pubs={["The Marksman", "The Approach Tavern"]} />);
+    });
+    await waitForEffects();
+
+    const button = host.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Pick a random pub for me");
+    expect(host.querySelector(".random-pub-picker__result")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  test("reveals a pub from the list when clicked", async () => {
+    setSearch("randomPub=1");
+    const pubs = ["The Marksman", "The Approach Tavern"];
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<RandomPubPicker pubs={pubs} />);
+    });
+    await waitForEffects();
+
+    const button = host.querySelector("button");
+    await act(async () => {
+      button?.click();
+    });
+    await waitForEffects();
+
+    const result = host.querySelector(".random-pub-picker__result");
+    expect(result).not.toBeNull();
+    expect(pubs.some((pub) => result?.textContent?.includes(pub))).toBe(true);
+    expect(host.querySelector("button")?.textContent).toContain("Pick another");
+
+    await act(async () => root.unmount());
+  });
+});

--- a/src/components/random-pub-picker/random-pub-picker.tsx
+++ b/src/components/random-pub-picker/random-pub-picker.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import "./random-pub-picker.css";
+
+const QUERY_PARAM = "randomPub";
+
+type Props = {
+  pubs: string[];
+};
+
+export default function RandomPubPicker({ pubs }: Props) {
+  const [enabled, setEnabled] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setEnabled(params.has(QUERY_PARAM));
+  }, []);
+
+  if (!enabled || pubs.length === 0) return null;
+
+  function pickRandomPub(): void {
+    const index = Math.floor(Math.random() * pubs.length);
+    setSelected(pubs[index]);
+  }
+
+  return (
+    <div className="random-pub-picker">
+      <button type="button" className="random-pub-picker__btn" onClick={pickRandomPub}>
+        {selected ? "Pick another" : "Pick a random pub for me"}
+      </button>
+      {selected && (
+        <p className="random-pub-picker__result">
+          Tonight's roast: <strong>{selected}</strong>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/extractListItems.test.ts
+++ b/src/lib/extractListItems.test.ts
@@ -31,4 +31,39 @@ describe("extractListItems", () => {
 
     expect(extractListItems(html)).toEqual([]);
   });
+
+  test("falls back to splitting <br>-separated lines within a paragraph", () => {
+    const html =
+      '<p class="wp-block-paragraph">Some intro text.</p>' +
+      '<p class="wp-block-paragraph"><br />Prospect Of Whitby – Wapping<br />The Ned, Bank<br />' +
+      "Rules, The Strand (Monday to Sunday)</p>";
+
+    expect(extractListItems(html)).toEqual([
+      "Prospect Of Whitby – Wapping",
+      "The Ned, Bank",
+      "Rules, The Strand (Monday to Sunday)"
+    ]);
+  });
+
+  test("ignores plain paragraphs with no <br> line breaks", () => {
+    const html =
+      '<p class="wp-block-paragraph">Everyone needs a to-do list.</p>' +
+      '<p class="wp-block-paragraph">Now also featuring recommender.</p>';
+
+    expect(extractListItems(html)).toEqual([]);
+  });
+
+  test("ignores a paragraph with too few <br>-separated lines to be a list", () => {
+    const html = '<p class="wp-block-paragraph">First line<br />Second line</p>';
+
+    expect(extractListItems(html)).toEqual([]);
+  });
+
+  test("prefers <li> items over <br>-separated paragraphs when both exist", () => {
+    const html =
+      "<ul><li>The Marksman</li></ul>" +
+      '<p class="wp-block-paragraph">A<br />B<br />C</p>';
+
+    expect(extractListItems(html)).toEqual(["The Marksman"]);
+  });
 });

--- a/src/lib/extractListItems.test.ts
+++ b/src/lib/extractListItems.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { extractListItems } from "./extractListItems";
+
+describe("extractListItems", () => {
+  test("returns the text content of each list item", () => {
+    const html = "<ul><li>The Approach Tavern</li><li>The Marksman</li></ul>";
+
+    expect(extractListItems(html)).toEqual(["The Approach Tavern", "The Marksman"]);
+  });
+
+  test("strips nested tags such as links and formatting", () => {
+    const html = '<ul><li><a href="/the-approach-tavern">The Approach Tavern</a> - Bethnal Green</li></ul>';
+
+    expect(extractListItems(html)).toEqual(["The Approach Tavern - Bethnal Green"]);
+  });
+
+  test("decodes common HTML entities and collapses whitespace", () => {
+    const html = "<li>Nell&#39;s   &amp;   Sons</li>";
+
+    expect(extractListItems(html)).toEqual(["Nell's & Sons"]);
+  });
+
+  test("ignores empty list items", () => {
+    const html = "<ul><li></li><li>  </li><li>The Marksman</li></ul>";
+
+    expect(extractListItems(html)).toEqual(["The Marksman"]);
+  });
+
+  test("returns an empty array when there are no list items", () => {
+    const html = "<p>No pubs listed yet.</p>";
+
+    expect(extractListItems(html)).toEqual([]);
+  });
+});

--- a/src/lib/extractListItems.ts
+++ b/src/lib/extractListItems.ts
@@ -1,5 +1,10 @@
 const TAG_PATTERN = /<[^>]+>/g;
 const LIST_ITEM_PATTERN = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+const PARAGRAPH_PATTERN = /<p[^>]*>([\s\S]*?)<\/p>/gi;
+const HAS_BREAK_PATTERN = /<br\s*\/?>/i;
+const BREAK_SPLIT_PATTERN = /<br\s*\/?>/gi;
+
+const MIN_LINE_BREAK_ITEMS = 3;
 
 const ENTITY_PATTERN = /&amp;|&lt;|&gt;|&quot;|&#0?39;|&apos;|&nbsp;/g;
 const ENTITY_MAP: Record<string, string> = {
@@ -16,12 +21,34 @@ const ENTITY_MAP: Record<string, string> = {
 const decodeEntities = (text: string): string =>
   text.replace(ENTITY_PATTERN, (match) => ENTITY_MAP[match] ?? match);
 
-export const extractListItems = (html: string): string[] => {
+const cleanText = (raw: string): string =>
+  decodeEntities(raw.replace(TAG_PATTERN, " "))
+    .replace(/\s+/g, " ")
+    .trim();
+
+const extractFromListItems = (html: string): string[] => {
   const matches = html.match(LIST_ITEM_PATTERN) ?? [];
 
   return matches
     .map((li) => li.replace(/^<li[^>]*>/i, "").replace(/<\/li>$/i, ""))
-    .map((inner) => decodeEntities(inner.replace(TAG_PATTERN, " ")))
-    .map((text) => text.replace(/\s+/g, " ").trim())
+    .map(cleanText)
     .filter((text) => text.length > 0);
+};
+
+const extractFromLineBreakParagraphs = (html: string): string[] => {
+  const paragraphs = html.match(PARAGRAPH_PATTERN) ?? [];
+
+  return paragraphs
+    .filter((paragraph) => HAS_BREAK_PATTERN.test(paragraph))
+    .flatMap((paragraph) => paragraph.split(BREAK_SPLIT_PATTERN))
+    .map(cleanText)
+    .filter((text) => text.length > 0);
+};
+
+export const extractListItems = (html: string): string[] => {
+  const listItems = extractFromListItems(html);
+  if (listItems.length > 0) return listItems;
+
+  const lineBreakItems = extractFromLineBreakParagraphs(html);
+  return lineBreakItems.length >= MIN_LINE_BREAK_ITEMS ? lineBreakItems : [];
 };

--- a/src/lib/extractListItems.ts
+++ b/src/lib/extractListItems.ts
@@ -1,0 +1,27 @@
+const TAG_PATTERN = /<[^>]+>/g;
+const LIST_ITEM_PATTERN = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+
+const ENTITY_PATTERN = /&amp;|&lt;|&gt;|&quot;|&#0?39;|&apos;|&nbsp;/g;
+const ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&#039;": "'",
+  "&apos;": "'",
+  "&nbsp;": " "
+};
+
+const decodeEntities = (text: string): string =>
+  text.replace(ENTITY_PATTERN, (match) => ENTITY_MAP[match] ?? match);
+
+export const extractListItems = (html: string): string[] => {
+  const matches = html.match(LIST_ITEM_PATTERN) ?? [];
+
+  return matches
+    .map((li) => li.replace(/^<li[^>]*>/i, "").replace(/<\/li>$/i, ""))
+    .map((inner) => decodeEntities(inner.replace(TAG_PATTERN, " ")))
+    .map((text) => text.replace(/\s+/g, " ").trim())
+    .filter((text) => text.length > 0);
+};

--- a/src/pages/to-do-list.astro
+++ b/src/pages/to-do-list.astro
@@ -1,11 +1,13 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { extractListItems } from "../lib/extractListItems";
 import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import "../styles/post.css";
 import Comments from "../components/comments/comments.astro";
 import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
 import Newsletter from "../components/newsletter/newsletter.astro";
+import RandomPubPicker from "../components/random-pub-picker/random-pub-picker.tsx";
 
 export const prerender = true;
 
@@ -15,6 +17,8 @@ const variables = { id: "17" };
 const singlePage = await getSinglePageData({ variables });
 
 const threadedComments = organiseComments(singlePage.comments.nodes);
+const sanitizedContent = sanitizeContent(singlePage.content);
+const pubNames = extractListItems(sanitizedContent);
 ---
 
 <BaseLayout
@@ -27,7 +31,8 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
     title={singlePage.title}
   />
   <div class="container">
-    <div set:html={sanitizeContent(singlePage.content)} />
+    <div set:html={sanitizedContent} />
+    <RandomPubPicker pubs={pubNames} client:only="react" />
     <Newsletter />
 
     <Comments threadedComments={threadedComments} postId={singlePage.pageId} />


### PR DESCRIPTION
## Summary

- The [to-do list page](https://www.rdldn.co.uk/to-do-list) already lists pubs to visit as a WordPress-authored bullet list. Added a "pick a random pub for me" feature that stays hidden from ordinary visitors and only appears when the URL has a `?randomPub` query param (e.g. `/to-do-list?randomPub`).
- `src/lib/extractListItems.ts` parses the sanitized page-content HTML and pulls plain-text pub names out of any `<li>` items (stripping nested tags/links, decoding entities, collapsing whitespace).
- `src/components/random-pub-picker/random-pub-picker.tsx` is a small React island (`client:only="react"`) that checks `window.location.search` for the `randomPub` param on mount; if present (and pubs exist), it renders a button that reveals a randomly chosen pub name on click. Otherwise it renders nothing.
- Wired into `src/pages/to-do-list.astro`, reusing the existing sanitized content and passing the extracted pub names to the new component.
- Styling reuses the existing button conventions from `wishlist-button`/`visit-button` (same border/color variables) for visual consistency.

## Test plan

- [x] `yarn vitest run` — full suite (479 tests) passes, including new tests for `extractListItems` and `RandomPubPicker`
- [x] `yarn lint` — no new issues in changed files
- [x] `yarn ts-check` — 0 errors
- [ ] Manually verify on a deployed preview that `/to-do-list` looks unchanged by default, and `/to-do-list?randomPub` shows the button and reveals a pub name from the real WordPress list content

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHaVDWECEGthQNoN52Jin4)_