### PR TITLE
Feature: "Which Tube Line Has the Best Roast Dinners?" stats page

### DIFF
--- a/src/layouts/TubeLinePageLayout.astro
+++ b/src/layouts/TubeLinePageLayout.astro
@@ -108,6 +108,12 @@ const stationBranches: TubeLineBranch[] = branches ?? [
         ))
       }
     </section>
+    <p>
+      See how the {lineName} line compares to other lines →{" "}
+      <a href="/which-tube-line-has-the-best-roast-dinners-in-london">
+        Which tube line has the best roast dinners?
+      </a>
+    </p>
   </div>
 
   <Newsletter />

--- a/src/pages/tube-stations-with-roast-dinner-reviews.astro
+++ b/src/pages/tube-stations-with-roast-dinner-reviews.astro
@@ -717,6 +717,12 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
           Array.from(new Set(tubeLines.flatMap((line) => line.stations))).length
         } on my adventures
       </p>
+      <p>
+        Curious which line comes out on top? See{" "}
+        <a href="/which-tube-line-has-the-best-roast-dinners-in-london">
+          which tube line has the best roast dinners
+        </a>.
+      </p>
     </div>
 
     <Newsletter />

--- a/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.astro
@@ -1,0 +1,141 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { sanitizeContent } from "../lib/sanitize";
+import { organiseComments } from "../lib/utils";
+import type { Post, PostsConnection } from "../types";
+import "../styles/post.css";
+import "../styles/tube-line-stats.css";
+import Comments from "../components/comments/comments.astro";
+import FeaturedPostHeader from "../components/featured-post-header/featured-post-header.astro";
+import Newsletter from "../components/newsletter/newsletter.astro";
+import { fetchGraphQL } from "../lib/api";
+
+export const prerender = true;
+
+import { getSinglePageData } from "../lib/getSinglePageData";
+import GET_ALL_POSTS from "../lib/queries/getAllPosts";
+
+const variables = { id: "12357" };
+const singlePage = await getSinglePageData({ variables });
+
+const MIN_REVIEWS = 3;
+
+const tubeLinePageSlugs: Record<string, string> = {
+  Bakerloo: "best-roast-dinners-on-the-bakerloo-line",
+  Central: "best-roast-dinners-on-the-central-line",
+  Elizabeth: "best-roast-dinners-on-the-elizabeth-line",
+  Jubilee: "best-roast-dinners-on-the-jubilee-line",
+  Metropolitan: "best-roast-dinners-on-the-metropolitan-line",
+  Piccadilly: "best-roast-dinners-on-the-piccadilly-line",
+  Victoria: "best-roast-dinners-on-the-victoria-line",
+};
+
+type LineStats = {
+  total: number;
+  count: number;
+  bestPost?: { title: string; slug: string; rating: number };
+};
+
+const lineStats: Record<string, LineStats> = {};
+
+let hasNextPage = true;
+let endCursor: string | null = null;
+
+while (hasNextPage) {
+  const variables: { after?: string } = endCursor ? { after: endCursor } : {};
+  const { posts } = await fetchGraphQL<{ posts: PostsConnection }>(GET_ALL_POSTS, variables);
+
+  // b: <explanation>
+  posts.nodes.forEach((post: Post) => {
+    const lineName = post.tubeLines?.nodes?.[0]?.name;
+    const ratingStr = post.ratings?.nodes?.[0]?.name;
+    const match = ratingStr?.match(/[\d.]+/);
+    const rating = match ? Number.parseFloat(match[0]) : null;
+
+    if (!lineName || !rating || Number.isNaN(rating)) return;
+
+    if (!lineStats[lineName]) {
+      lineStats[lineName] = { total: 0, count: 0 };
+    }
+
+    lineStats[lineName].total += rating;
+    lineStats[lineName].count += 1;
+
+    const currentBest = lineStats[lineName].bestPost;
+    if (post.slug && post.title && (!currentBest || rating > currentBest.rating)) {
+      lineStats[lineName].bestPost = { title: post.title, slug: post.slug, rating };
+    }
+  });
+
+  hasNextPage = posts.pageInfo.hasNextPage;
+  endCursor = posts.pageInfo.endCursor;
+}
+
+const lineComparison = Object.entries(lineStats)
+  .filter(([_, stats]) => stats.count >= MIN_REVIEWS)
+  .map(([name, stats]) => ({
+    name,
+    average: +(stats.total / stats.count).toFixed(2),
+    count: stats.count,
+    bestPost: stats.bestPost,
+  }))
+  .sort((a, b) => b.average - a.average);
+
+const threadedComments = organiseComments(singlePage.comments.nodes);
+---
+
+<BaseLayout
+  pageTitle={singlePage.title}
+  description={singlePage?.seo?.opengraphDescription}
+  opengraphImage={singlePage?.seo?.opengraphImage?.sourceUrl}
+>
+  <FeaturedPostHeader
+    imageSrc={singlePage?.featuredImage?.node?.sourceUrl}
+    title={singlePage.title}
+  />
+  <div class="container">
+    <div set:html={sanitizeContent(singlePage.content)} />
+    <ul class="tube-line-chart">
+      {
+        lineComparison.map((line) => {
+          const lineSlug = tubeLinePageSlugs[line.name];
+          return (
+            <li class="tube-line-chart-row">
+              <div class="bar-track" role="presentation" aria-hidden="true">
+                <div
+                  class="bar-fill"
+                  style={`width: ${Math.round((line.average / 10) * 100)}%`}
+                />
+              </div>
+              The{" "}
+              {lineSlug ? (
+                <a href={`/${lineSlug}`}>{line.name} line</a>
+              ) : (
+                <>{line.name} line</>
+              )}{" "}
+              averages {line.average.toFixed(2)} based on {line.count}{" "}
+              {line.count === 1 ? "review" : "reviews"}
+              {line.bestPost && (
+                <>
+                  {" "}
+                  – best roast:{" "}
+                  <a href={`/${line.bestPost.slug}`}>{line.bestPost.title}</a>
+                </>
+              )}
+            </li>
+          );
+        })
+      }
+    </ul>
+    <p>
+      Do note that I am only including tube lines where I've had {MIN_REVIEWS}{" "}
+      roast dinners or more. See the{" "}
+      <a href="/tube-stations-with-roast-dinner-reviews">
+        tube station tracker
+      </a> for every station reviewed.
+    </p>
+
+    <Newsletter />
+    <Comments threadedComments={threadedComments} postId={singlePage.pageId} />
+  </div>
+</BaseLayout>

--- a/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.astro
+++ b/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { toOwnerSlug } from "../lib/ownerSlug";
 import { sanitizeContent } from "../lib/sanitize";
 import { organiseComments } from "../lib/utils";
 import type { Post, PostsConnection } from "../types";
@@ -30,6 +31,9 @@ const tubeLinePageSlugs: Record<string, string> = {
   Victoria: "best-roast-dinners-on-the-victoria-line",
 };
 
+// Matches the --<line> custom properties defined in layouts/layout.css
+const toLineColorClass = (lineName: string) => toOwnerSlug(lineName).replace(/-/g, "");
+
 type LineStats = {
   total: number;
   count: number;
@@ -47,24 +51,29 @@ while (hasNextPage) {
 
   // b: <explanation>
   posts.nodes.forEach((post: Post) => {
-    const lineName = post.tubeLines?.nodes?.[0]?.name;
+    const lineNames = post.tubeLines?.nodes?.map((line) => line.name) ?? [];
     const ratingStr = post.ratings?.nodes?.[0]?.name;
     const match = ratingStr?.match(/[\d.]+/);
     const rating = match ? Number.parseFloat(match[0]) : null;
 
-    if (!lineName || !rating || Number.isNaN(rating)) return;
+    if (!lineNames.length || !rating || Number.isNaN(rating)) return;
 
-    if (!lineStats[lineName]) {
-      lineStats[lineName] = { total: 0, count: 0 };
-    }
+    const isClosedDown = (post.closedDowns?.nodes.length ?? 0) > 0;
 
-    lineStats[lineName].total += rating;
-    lineStats[lineName].count += 1;
+    // A station can serve more than one line, so credit the review to every line it's on
+    lineNames.forEach((lineName) => {
+      if (!lineStats[lineName]) {
+        lineStats[lineName] = { total: 0, count: 0 };
+      }
 
-    const currentBest = lineStats[lineName].bestPost;
-    if (post.slug && post.title && (!currentBest || rating > currentBest.rating)) {
-      lineStats[lineName].bestPost = { title: post.title, slug: post.slug, rating };
-    }
+      lineStats[lineName].total += rating;
+      lineStats[lineName].count += 1;
+
+      const currentBest = lineStats[lineName].bestPost;
+      if (post.slug && post.title && !isClosedDown && (!currentBest || rating > currentBest.rating)) {
+        lineStats[lineName].bestPost = { title: post.title, slug: post.slug, rating };
+      }
+    });
   });
 
   hasNextPage = posts.pageInfo.hasNextPage;
@@ -99,37 +108,27 @@ const threadedComments = organiseComments(singlePage.comments.nodes);
       {
         lineComparison.map((line) => {
           const lineSlug = tubeLinePageSlugs[line.name];
+          const lineNameLink = lineSlug ? <a href={`/${lineSlug}`}>{line.name} line</a> : <>{line.name} line</>;
+          const reviewWord = line.count === 1 ? "review" : "reviews";
           return (
             <li class="tube-line-chart-row">
               <div class="bar-track" role="presentation" aria-hidden="true">
                 <div
-                  class="bar-fill"
+                  class={`bar-fill ${toLineColorClass(line.name)}`}
                   style={`width: ${Math.round((line.average / 10) * 100)}%`}
                 />
               </div>
-              The{" "}
-              {lineSlug ? (
-                <a href={`/${lineSlug}`}>{line.name} line</a>
-              ) : (
-                <>{line.name} line</>
-              )}{" "}
-              averages {line.average.toFixed(2)} based on {line.count}{" "}
-              {line.count === 1 ? "review" : "reviews"}
-              {line.bestPost && (
-                <>
-                  {" "}
-                  – best roast:{" "}
-                  <a href={`/${line.bestPost.slug}`}>{line.bestPost.title}</a>
-                </>
-              )}
+              <p class="tube-line-summary">
+                The {lineNameLink} averages {line.average.toFixed(2)} based on {line.count} {reviewWord}
+                {line.bestPost && <> – best roast: <a href={`/${line.bestPost.slug}`}>{line.bestPost.title}</a></>}
+              </p>
             </li>
           );
         })
       }
     </ul>
     <p>
-      Do note that I am only including tube lines where I've had {MIN_REVIEWS}{" "}
-      roast dinners or more. See the{" "}
+      See the{" "}
       <a href="/tube-stations-with-roast-dinner-reviews">
         tube station tracker
       </a> for every station reviewed.

--- a/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.test.ts
+++ b/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.test.ts
@@ -1,0 +1,164 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const fetchGraphQLMock = vi.fn();
+
+vi.mock("../components/header/HeaderAuth");
+
+vi.mock("../lib/getSinglePageData", () => ({
+  getSinglePageData: vi.fn(async () => ({
+    id: "page-tube-line-best",
+    pageId: "12357",
+    slug: "which-tube-line-has-the-best-roast-dinners-in-london",
+    title: "Which Tube Line Has The Best Roast Dinners In London?",
+    content: "<p>Tube line averages by roast rating.</p>",
+    featuredImage: { node: { sourceUrl: "https://example.com/tube-line-best.jpg" } },
+    comments: { nodes: [] },
+    seo: {
+      opengraphDescription: "Best tube line roast averages.",
+      opengraphImage: { sourceUrl: "https://example.com/tube-line-best-og.jpg" }
+    }
+  }))
+}));
+
+vi.mock("../lib/api", () => ({
+  fetchGraphQL: fetchGraphQLMock
+}));
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  )
+}));
+
+beforeEach(() => {
+  fetchGraphQLMock.mockReset();
+  vi.resetModules();
+
+  fetchGraphQLMock.mockImplementation(async (_query: string, variables: Record<string, unknown> = {}) => {
+    if (!variables.after) {
+      return {
+        posts: {
+          nodes: [
+            {
+              tubeLines: { nodes: [{ name: "Elizabeth" }] },
+              ratings: { nodes: [{ name: "9.0" }] },
+              slug: "the-elizabeth-arms",
+              title: "The Elizabeth Arms"
+            },
+            {
+              tubeLines: { nodes: [{ name: "Elizabeth" }] },
+              ratings: { nodes: [{ name: "7.0" }] },
+              slug: "the-elizabeth-pub",
+              title: "The Elizabeth Pub"
+            },
+            {
+              tubeLines: { nodes: [{ name: "Jubilee" }] },
+              ratings: { nodes: [{ name: "6.0" }] },
+              slug: "the-jubilee-arms",
+              title: "The Jubilee Arms"
+            },
+            {
+              tubeLines: { nodes: [{ name: "Jubilee" }] },
+              ratings: { nodes: [{ name: "7.0" }] },
+              slug: "the-jubilee-inn",
+              title: "The Jubilee Inn"
+            },
+            {
+              tubeLines: { nodes: [{ name: "Overground" }] },
+              ratings: { nodes: [{ name: "10.0" }] },
+              slug: "the-overground-arms",
+              title: "The Overground Arms"
+            },
+            {
+              tubeLines: { nodes: [{ name: "Elizabeth" }] },
+              ratings: { nodes: [{ name: "not-a-number" }] },
+              slug: "bad-rating",
+              title: "Bad Rating Roast"
+            },
+            {
+              tubeLines: { nodes: [] },
+              ratings: { nodes: [{ name: "8.2" }] },
+              slug: "no-line",
+              title: "No Line Roast"
+            }
+          ],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" }
+        }
+      };
+    }
+
+    return {
+      posts: {
+        nodes: [
+          {
+            tubeLines: { nodes: [{ name: "Elizabeth" }] },
+            ratings: { nodes: [{ name: "8.0" }] },
+            slug: "the-elizabeth-tavern",
+            title: "The Elizabeth Tavern"
+          },
+          {
+            tubeLines: { nodes: [{ name: "Jubilee" }] },
+            ratings: { nodes: [{ name: "8.0" }] },
+            slug: "the-jubilee-tavern",
+            title: "The Jubilee Tavern"
+          },
+          {
+            tubeLines: { nodes: [{ name: "Jubilee" }] },
+            ratings: undefined,
+            slug: "missing-rating",
+            title: "Missing Rating Roast"
+          }
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null }
+      }
+    };
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("which-tube-line-has-the-best-roast-dinners-in-london page", () => {
+  test("renders tube line averages with minimum 3 reviews sorted high to low, linking best review and per-line page", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import(
+      "./which-tube-line-has-the-best-roast-dinners-in-london.astro"
+    );
+    const html = await container.renderToString(Page);
+
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(2);
+    expect(fetchGraphQLMock).toHaveBeenNthCalledWith(1, expect.anything(), {});
+    expect(fetchGraphQLMock).toHaveBeenNthCalledWith(2, expect.anything(), { after: "cursor-1" });
+
+    expect(html).toContain("Which Tube Line Has The Best Roast Dinners In London?");
+
+    expect(html).toContain('href="/best-roast-dinners-on-the-elizabeth-line"');
+    expect(html).toContain("Elizabeth line");
+    expect(html).toMatch(/averages\s+8\.00\s+based on\s+3\s+reviews/);
+
+    expect(html).toContain('href="/best-roast-dinners-on-the-jubilee-line"');
+    expect(html).toMatch(/averages\s+7\.00\s+based on\s+3\s+reviews/);
+
+    expect(html).toContain('href="/the-elizabeth-arms"');
+    expect(html).toContain("The Elizabeth Arms");
+
+    // Overground has only 1 review, below the minimum threshold — excluded
+    expect(html).not.toContain("Overground line");
+    expect(html).not.toContain("The Overground Arms");
+
+    // Posts with no tube line or an unparsable rating are ignored
+    expect(html).not.toContain("No Line Roast");
+    expect(html).not.toContain("Bad Rating Roast");
+
+    const elizabethIndex = html.indexOf("Elizabeth line");
+    const jubileeIndex = html.indexOf("Jubilee line");
+    expect(elizabethIndex).toBeLessThan(jubileeIndex);
+
+    expect(html).toContain('href="/tube-stations-with-roast-dinner-reviews"');
+  });
+});

--- a/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.test.ts
+++ b/src/pages/which-tube-line-has-the-best-roast-dinners-in-london.test.ts
@@ -43,46 +43,47 @@ beforeEach(() => {
         posts: {
           nodes: [
             {
-              tubeLines: { nodes: [{ name: "Elizabeth" }] },
+              // Interchange station – rated on both the Elizabeth and Jubilee lines
+              tubeLines: { nodes: [{ name: "Elizabeth" }, { name: "Jubilee" }] },
               ratings: { nodes: [{ name: "9.0" }] },
               slug: "the-elizabeth-arms",
-              title: "The Elizabeth Arms"
+              title: "The Elizabeth Arms",
+              closedDowns: { nodes: [{ name: "Closed" }] }
             },
             {
               tubeLines: { nodes: [{ name: "Elizabeth" }] },
               ratings: { nodes: [{ name: "7.0" }] },
               slug: "the-elizabeth-pub",
-              title: "The Elizabeth Pub"
+              title: "The Elizabeth Pub",
+              closedDowns: { nodes: [] }
             },
             {
               tubeLines: { nodes: [{ name: "Jubilee" }] },
               ratings: { nodes: [{ name: "6.0" }] },
               slug: "the-jubilee-arms",
-              title: "The Jubilee Arms"
-            },
-            {
-              tubeLines: { nodes: [{ name: "Jubilee" }] },
-              ratings: { nodes: [{ name: "7.0" }] },
-              slug: "the-jubilee-inn",
-              title: "The Jubilee Inn"
+              title: "The Jubilee Arms",
+              closedDowns: { nodes: [] }
             },
             {
               tubeLines: { nodes: [{ name: "Overground" }] },
               ratings: { nodes: [{ name: "10.0" }] },
               slug: "the-overground-arms",
-              title: "The Overground Arms"
+              title: "The Overground Arms",
+              closedDowns: { nodes: [] }
             },
             {
               tubeLines: { nodes: [{ name: "Elizabeth" }] },
               ratings: { nodes: [{ name: "not-a-number" }] },
               slug: "bad-rating",
-              title: "Bad Rating Roast"
+              title: "Bad Rating Roast",
+              closedDowns: { nodes: [] }
             },
             {
               tubeLines: { nodes: [] },
               ratings: { nodes: [{ name: "8.2" }] },
               slug: "no-line",
-              title: "No Line Roast"
+              title: "No Line Roast",
+              closedDowns: { nodes: [] }
             }
           ],
           pageInfo: { hasNextPage: true, endCursor: "cursor-1" }
@@ -97,19 +98,22 @@ beforeEach(() => {
             tubeLines: { nodes: [{ name: "Elizabeth" }] },
             ratings: { nodes: [{ name: "8.0" }] },
             slug: "the-elizabeth-tavern",
-            title: "The Elizabeth Tavern"
+            title: "The Elizabeth Tavern",
+            closedDowns: { nodes: [] }
           },
           {
             tubeLines: { nodes: [{ name: "Jubilee" }] },
             ratings: { nodes: [{ name: "8.0" }] },
             slug: "the-jubilee-tavern",
-            title: "The Jubilee Tavern"
+            title: "The Jubilee Tavern",
+            closedDowns: { nodes: [] }
           },
           {
             tubeLines: { nodes: [{ name: "Jubilee" }] },
             ratings: undefined,
             slug: "missing-rating",
-            title: "Missing Rating Roast"
+            title: "Missing Rating Roast",
+            closedDowns: { nodes: [] }
           }
         ],
         pageInfo: { hasNextPage: false, endCursor: null }
@@ -137,15 +141,23 @@ describe("which-tube-line-has-the-best-roast-dinners-in-london page", () => {
 
     expect(html).toContain("Which Tube Line Has The Best Roast Dinners In London?");
 
+    // Elizabeth: The Elizabeth Arms (9.0) + The Elizabeth Pub (7.0) + The Elizabeth Tavern (8.0) = 3 reviews, avg 8.00
     expect(html).toContain('href="/best-roast-dinners-on-the-elizabeth-line"');
     expect(html).toContain("Elizabeth line");
     expect(html).toMatch(/averages\s+8\.00\s+based on\s+3\s+reviews/);
 
+    // Jubilee: The Elizabeth Arms (interchange, 9.0) + The Jubilee Arms (6.0) + The Jubilee Tavern (8.0) = 3 reviews, avg 7.67
     expect(html).toContain('href="/best-roast-dinners-on-the-jubilee-line"');
-    expect(html).toMatch(/averages\s+7\.00\s+based on\s+3\s+reviews/);
+    expect(html).toMatch(/averages\s+7\.67\s+based on\s+3\s+reviews/);
 
-    expect(html).toContain('href="/the-elizabeth-arms"');
-    expect(html).toContain("The Elizabeth Arms");
+    // The Elizabeth Arms has the highest rating (9.0) but is closed down, so it must not be linked as "best roast"
+    expect(html).not.toContain('href="/the-elizabeth-arms"');
+    expect(html).toContain('href="/the-elizabeth-tavern"');
+    expect(html).toContain("The Elizabeth Tavern");
+
+    // Jubilee's best open review is The Jubilee Tavern (8.0) — The Jubilee Arms (6.0) is lower
+    expect(html).toContain('href="/the-jubilee-tavern"');
+    expect(html).toContain("The Jubilee Tavern");
 
     // Overground has only 1 review, below the minimum threshold — excluded
     expect(html).not.toContain("Overground line");
@@ -155,9 +167,14 @@ describe("which-tube-line-has-the-best-roast-dinners-in-london page", () => {
     expect(html).not.toContain("No Line Roast");
     expect(html).not.toContain("Bad Rating Roast");
 
+    // Elizabeth (8.00) outranks Jubilee (7.67)
     const elizabethIndex = html.indexOf("Elizabeth line");
     const jubileeIndex = html.indexOf("Jubilee line");
     expect(elizabethIndex).toBeLessThan(jubileeIndex);
+
+    // Bars are coloured per tube line
+    expect(html).toContain('bar-fill elizabeth');
+    expect(html).toContain('bar-fill jubilee');
 
     expect(html).toContain('href="/tube-stations-with-roast-dinner-reviews"');
   });

--- a/src/styles/tube-line-stats.css
+++ b/src/styles/tube-line-stats.css
@@ -1,0 +1,29 @@
+.tube-line-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 1.5rem 0;
+  padding: 0;
+}
+
+.tube-line-chart-row {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.tube-line-chart-row .bar-track {
+  background: #e5e7eb;
+  border-radius: 4px;
+  height: 0.75rem;
+  overflow: hidden;
+  max-width: 400px;
+}
+
+.tube-line-chart-row .bar-fill {
+  height: 100%;
+  background: var(--roast-new-blue);
+  border-radius: 4px;
+  min-width: 2px;
+}

--- a/src/styles/tube-line-stats.css
+++ b/src/styles/tube-line-stats.css
@@ -1,7 +1,6 @@
 .tube-line-chart {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
   margin: 1.5rem 0;
   padding: 0;
 }
@@ -11,6 +10,15 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.tube-line-chart-row:last-child {
+  margin-bottom: 0;
+}
+
+.tube-line-summary {
+  margin: 0;
 }
 
 .tube-line-chart-row .bar-track {
@@ -26,4 +34,41 @@
   background: var(--roast-new-blue);
   border-radius: 4px;
   min-width: 2px;
+
+  &.bakerloo {
+    background: var(--bakerloo);
+  }
+  &.central {
+    background: var(--central);
+  }
+  &.circle {
+    background: var(--circle);
+  }
+  &.district {
+    background: var(--district);
+  }
+  &.hammersmithandcity {
+    background: var(--hammersmithandcity);
+  }
+  &.jubilee {
+    background: var(--jubilee);
+  }
+  &.metropolitan {
+    background: var(--metropolitan);
+  }
+  &.northern {
+    background: var(--northern);
+  }
+  &.piccadilly {
+    background: var(--piccadilly);
+  }
+  &.victoria {
+    background: var(--victoria);
+  }
+  &.elizabeth {
+    background: var(--elizabeth);
+  }
+  &.overground {
+    background: var(--overground);
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `/which-tube-line-has-the-best-roast-dinners-in-london`, comparing average roast dinner rating per tube line (min 3 reviews to qualify), sorted highest to lowest, with a horizontal bar-chart visual and a link to each line's highest-rated review.
- Cross-links the new page from every existing per-line best-of page (`TubeLinePageLayout.astro`, e.g. `/best-roast-dinners-on-the-elizabeth-line`) and from `/tube-stations-with-roast-dinner-reviews`.
- The page automatically appears on `/roastatistics` once the corresponding WordPress page (id `12357`, used for this page's title/content/SEO/featured image) is tagged `roastatistics` in the CMS — no code change needed there.

Closes #542

## Test plan
- [x] `yarn vitest run` — all 484 tests pass, including new coverage for min-review filtering, sorting, best-review linking, and per-line page linking
- [x] `yarn astro check` — no new errors/warnings
- [ ] Manual check once the WordPress page (id `12357`) is published with content and tagged `roastatistics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
