### PR TITLE
Cover update-on-new-best and create-user branches in personal-best API

### DIFF
--- a/src/pages/guessthescore/api/personal-best.test.ts
+++ b/src/pages/guessthescore/api/personal-best.test.ts
@@ -99,4 +99,46 @@ describe("POST /guessthescore/api/personal-best", () => {
     expect(data.saved).toBe(true);
     expect(data.personalBest).toBe(75);
   });
+
+  test("updates the personal best record when the new score is higher than the existing one", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([{ id: "user-123" }]) as never)
+      .mockReturnValueOnce(makeSelectChain([{ id: "pb-1", score: 60 }]) as never);
+    const whereMock = vi.fn().mockResolvedValue([]);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: whereMock }),
+    } as never);
+
+    const response = await POST(makeContext("clerk_abc", { score: 80 }));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.saved).toBe(true);
+    expect(data.personalBest).toBe(80);
+    expect(db.update).toHaveBeenCalled();
+    expect(whereMock).toHaveBeenCalled();
+  });
+
+  test("creates a new user record when none exists before saving the personal best", async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([]) as never)
+      .mockReturnValueOnce(makeSelectChain([]) as never);
+    vi.mocked(db.insert)
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "new-user-456" }]),
+        }),
+      } as never)
+      .mockReturnValueOnce({
+        values: vi.fn().mockResolvedValue([]),
+      } as never);
+
+    const response = await POST(makeContext("new_clerk", { score: 50 }));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.saved).toBe(true);
+    expect(data.personalBest).toBe(50);
+    expect(db.insert).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

Two execution branches in `src/pages/guessthescore/api/personal-best.ts` had no test coverage:

- **Update branch**: when a user submits a score that beats their existing personal best, the handler calls `db.update`. This path was never exercised — a bug here (wrong field, wrong condition) would be silent.
- **Create-user branch**: when an authenticated Clerk user has no row in the `users` table yet, the handler calls `db.insert` to create one, then calls `db.insert` again to record the personal best. This two-insert path was also untested.

Both new tests mock `db.select`, `db.insert`, and `db.update` to drive the code down the correct branch and assert the expected response shape and mock call expectations.

**Test count**: 477 → 479 (all 122 files passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMbVoc3F1ctA3NY8HaAyrr)_