### PR TITLE
Newsletter popup dismiss and focus-trap behaviour

### DIFF
--- a/tests/e2e/newsletter-popup.spec.ts
+++ b/tests/e2e/newsletter-popup.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+const showPopup = async (page: import("@playwright/test").Page) => {
+  await page.evaluate(() => {
+    const overlay = document.getElementById("newsletter-popup-overlay");
+    if (overlay) {
+      overlay.classList.add("visible");
+      overlay.setAttribute("aria-hidden", "false");
+    }
+  });
+};
+
+test.describe("newsletter popup", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.evaluate(() => localStorage.removeItem("newsletter-dismissed"));
+  });
+
+  test("dismisses via close button and persists dismissal to localStorage", async ({ page }) => {
+    await showPopup(page);
+
+    const overlay = page.locator("#newsletter-popup-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toHaveAttribute("aria-hidden", "false");
+
+    await page.locator("#newsletter-popup-close").click();
+
+    await expect(overlay).not.toBeVisible();
+    await expect(overlay).toHaveAttribute("aria-hidden", "true");
+
+    const stored = await page.evaluate(() => localStorage.getItem("newsletter-dismissed"));
+    expect(stored).not.toBeNull();
+  });
+
+  test("closes when clicking the overlay backdrop without saving to localStorage", async ({ page }) => {
+    await showPopup(page);
+
+    const overlay = page.locator("#newsletter-popup-overlay");
+    await expect(overlay).toBeVisible();
+
+    await overlay.click({ position: { x: 5, y: 5 } });
+
+    await expect(overlay).not.toBeVisible();
+
+    const stored = await page.evaluate(() => localStorage.getItem("newsletter-dismissed"));
+    expect(stored).toBeNull();
+  });
+
+  test("closes on Escape key press without saving to localStorage", async ({ page }) => {
+    await showPopup(page);
+
+    const overlay = page.locator("#newsletter-popup-overlay");
+    await expect(overlay).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(overlay).not.toBeVisible();
+
+    const stored = await page.evaluate(() => localStorage.getItem("newsletter-dismissed"));
+    expect(stored).toBeNull();
+  });
+
+  test("traps focus within the popup on Tab and Shift+Tab", async ({ page }) => {
+    await showPopup(page);
+
+    const closeBtn = page.locator("#newsletter-popup-close");
+    await closeBtn.focus();
+    await expect(closeBtn).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(closeBtn).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await expect(closeBtn).toBeFocused();
+  });
+});


### PR DESCRIPTION
Adds a Playwright e2e test suite for the newsletter popup component, which previously had no test coverage.

## What is tested

The popup has browser-side logic that can only be verified in a real browser:

- **Close button** — clicking it hides the popup and persists the dismissal timestamp to `localStorage`, so the popup won't reappear for three months
- **Backdrop click** — clicking the dark overlay outside the popup content hides it *without* writing to `localStorage` (not a permanent dismiss)
- **Escape key** — pressing Escape hides the popup without persisting the dismissal
- **Focus trap** — Tab and Shift+Tab keep focus locked inside the popup while it is open (preventing keyboard users from accidentally tabbing to content behind the overlay)

## What bugs these tests would catch

- `aria-hidden` not being toggled correctly on show/hide
- `localStorage` being written when it should not be (backdrop/Escape paths), or not being written when it should be (close-button path)
- Focus escaping the popup on Tab/Shift+Tab, breaking keyboard accessibility

## Notes

- Tests bypass the 5-second show timer by directly adding the `visible` class via `page.evaluate()` — this keeps the suite fast while still exercising the real DOM event handlers
- The Substack iframe is suppressed in the test environment (`PLAYWRIGHT=true`) via the existing guard in the component, so the only focusable element inside the popup during tests is the close button — which is why Tab always returns to it

---
_Generated by [Claude Code](https://claude.ai/code/session_015rqPTnp2AvNvnZEvm1yG4a)_