### PR TITLE
verify flags page renders cookie-driven checkbox state

### DIFF
--- a/src/pages/flags.test.ts
+++ b/src/pages/flags.test.ts
@@ -1,0 +1,49 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../components/header/HeaderAuth");
+
+vi.mock("astro:assets", () => ({
+  Image: Object.assign(
+    (_result: unknown, props: { src: string; alt?: string }) =>
+      `<img src="${props.src}" alt="${props.alt ?? ""}" />`,
+    { isAstroComponentFactory: true }
+  ),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("flags page", () => {
+  test("renders the Feature Flags heading and flag labels from FLAG_DEFINITIONS", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./flags.astro");
+    const html = await container.renderToString(Page);
+
+    expect(html).toContain("Feature Flags");
+    expect(html).toContain("Mark As Visited");
+    expect(html).toContain("Controls visibility of the mark as visited feature on review pages.");
+  });
+
+  test("renders visitTracking checkbox unchecked when no cookie is set", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./flags.astro");
+    const html = await container.renderToString(Page);
+
+    expect(html).toContain('name="flag_visitTracking"');
+    expect(html).not.toContain("checked");
+  });
+
+  test("renders visitTracking checkbox checked when flag_visitTracking cookie is true", async () => {
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./flags.astro");
+    const request = new Request("http://localhost:4321/flags", {
+      headers: { Cookie: "flag_visitTracking=true" },
+    });
+    const html = await container.renderToString(Page, { request });
+
+    expect(html).toContain('name="flag_visitTracking"');
+    expect(html).toContain("checked");
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for `src/pages/flags.astro` — the feature-flag admin page that was the only server-rendered page without any test coverage.

## Tests added (`src/pages/flags.test.ts`, 3 tests)

| Test | What it catches |
|------|----------------|
| Renders the Feature Flags heading and flag labels from `FLAG_DEFINITIONS` | Detects label/description renames or the template losing its loop |
| Checkbox unchecked when no cookie is set | Guards the `flag_${key}` cookie-name format and the `false` default |
| Checkbox checked when `flag_visitTracking=true` cookie is present | Guards the `cookie.value === "true"` comparison and cookie-name matching |

## Why this file

`flags.astro` reads per-flag cookies to decide whether to render each checkbox as `checked`. A silent rename of the cookie key (e.g. `flag_${key}` → `${key}`) or a change to the value comparison (`"true"` → `"1"`) would break the UI without any existing test catching it. The three tests together lock in the full GET rendering path.

---
_Generated by [Claude Code](https://claude.ai/code/session_014L8f9BsycMXKGfnJbf5ge3)_