### PR TITLE
Move roast-map inline styles to CSS classes

### DIFF
--- a/src/components/roast-map/roast-map.css
+++ b/src/components/roast-map/roast-map.css
@@ -1,0 +1,7 @@
+.roast-map__container {
+  height: 600px;
+}
+
+.roast-map__year-label {
+  margin-right: 1rem;
+}

--- a/src/components/roast-map/roast-map.tsx
+++ b/src/components/roast-map/roast-map.tsx
@@ -1,6 +1,7 @@
 import L from "leaflet";
 import { useEffect, useMemo, useRef, useState } from "react";
 import "leaflet/dist/leaflet.css";
+import "./roast-map.css";
 
 type Marker = {
   lat: number;
@@ -160,7 +161,7 @@ export default function RoastMap({ markers }: Props) {
         <fieldset>
           <legend>Filter by year visited:</legend>
           {availableYears.map((year) => (
-            <label key={year} style={{ marginRight: "1rem" }}>
+            <label key={year} className="roast-map__year-label">
               <input type="checkbox" checked={selectedYears.includes(year)} onChange={() => toggleYear(year)} />
               {year}
             </label>
@@ -180,7 +181,7 @@ export default function RoastMap({ markers }: Props) {
         hidden
       />
       {/** biome-ignore lint/correctness/useUniqueElementIds: <explanation> */}
-      <section id="map" ref={mapRef} style={{ height: "600px" }} aria-label="Map of reviewed roast dinner locations in London" />
+      <section id="map" ref={mapRef} className="roast-map__container" aria-label="Map of reviewed roast dinner locations in London" />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced `style={{ marginRight: "1rem" }}` on year-filter labels with a `.roast-map__year-label` CSS class
- Replaced `style={{ height: "600px" }}` on the map section element with a `.roast-map__container` CSS class
- Created `src/components/roast-map/roast-map.css` to hold both rules, following the existing per-component CSS file pattern (e.g. `random-pub-picker.css`, `sunday-roast-planner.css`)

## Category
Bad patterns — inline `style=` props in `.tsx` files (should be CSS classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019r5GtbytwVf7U8KgBoBLfd)_