### PR TITLE
fix: prevent CLS from incorrect featured-post-header image dimensions

### DIFF
--- a/src/components/featured-post-header/featured-post-header.astro
+++ b/src/components/featured-post-header/featured-post-header.astro
@@ -9,14 +9,7 @@ const { imageSrc, title, imageAlt = title }: Props = Astro.props;
 ---
 
 <div class="image-container">
-  <img
-    src={imageSrc}
-    alt={imageAlt}
-    width={5000}
-    height={5000}
-    class="featured-image"
-    loading="eager"
-  />
+  <img src={imageSrc} alt={imageAlt} class="featured-image" loading="eager" />
   <slot name="overlay" />
   <div class="copyright-overlay">
     © {new Date().getFullYear()} Roast Dinners in London. All rights reserved.

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -176,7 +176,6 @@ h4 {
   .featured-image {
     margin: 0 auto;
     max-width: 100%;
-    height: auto;
     margin-top: 64px;
 
     @media (min-width: 1024px) {
@@ -208,7 +207,8 @@ h4 {
 .featured-image {
   display: block;
   width: 100%;
-  height: auto;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
 }
 
 .copyright-overlay {


### PR DESCRIPTION
## Summary
- `featured-post-header.astro` hardcoded `width={5000} height={5000}` on the featured image regardless of the actual dimensions, causing the browser to reserve a 1:1 box that snaps to the real (usually landscape) aspect ratio once the image loads — a large CLS event on every post/tag/list page site-wide.
- Replaced the bogus HTML attributes with a CSS `aspect-ratio: 16 / 9` + `object-fit: cover` on `.featured-image`, so space is reserved correctly up front and every featured image is cropped to a consistent 16:9 shape (most source images are already 16:9, but not all).

Fixes #554

## Test plan
- [x] `yarn vitest run src/components/featured-post-header/featured-post-header.test.ts` — passing
- [x] `yarn astro check` — 0 errors
- [ ] Spot-check a post page visually to confirm no more layout jump on image load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
