### PR TITLE
Verify BestValue initialises filters from URL search params on mount

### DIFF
--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -282,3 +282,53 @@ describe("best-value component", () => {
     });
   });
 });
+
+describe("URL param initialisation", () => {
+  test("pre-populates area filter from URL search params on first render", async () => {
+    window.history.replaceState(null, "", "/?area=Soho");
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("pre-populates tubeLine filter from URL search params on first render", async () => {
+    window.history.replaceState(null, "", "/?tubeLine=Northern");
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Pricey And Mediocre"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("pre-populates borough filter from URL search params on first render", async () => {
+    window.history.replaceState(null, "", "/?borough=Westminster");
+
+    const { host, root } = createHost();
+    await act(async () => {
+      root.render(<BestValue posts={posts} />);
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Cheap And Great"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## What was tested

Adds three tests to `src/components/best-value/best-value.test.tsx` covering URL search param initialisation in the `useValueFilter` hook.

### Tests added (`describe("URL param initialisation")`)

- **pre-populates area filter from URL search params on first render** — sets `?area=Soho` before mount and asserts only the matching venue is shown
- **pre-populates tubeLine filter from URL search params on first render** — sets `?tubeLine=Northern` before mount and asserts only the matching venue is shown
- **pre-populates borough filter from URL search params on first render** — sets `?borough=Westminster` before mount and asserts only the matching venue is shown

### What bug this catches

`useValueFilter` reads `area`, `borough`, and `tubeLine` from `window.location.search` on initialisation to support shareable filtered links. This path (`getInitialStateFromUrl`) was completely untested — a typo in any param key, a broken `URLSearchParams` call, or a missing initialiser would silently cause shared links to show unfiltered results instead of the intended view.

### Test count

489 → 492 (all passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgXLz8zD7tZUzJ8UAFXQFH)_