### PR TITLE
perf: parallelize independent fetches in [slug].astro

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -86,11 +86,12 @@ export async function getStaticPaths() {
     const { slug } = Astro.params;
     const { contentType } = Astro.props;
 
-const { inflationIndex, mostRecentYear } = await buildInflationIndex();
-
-const data = await fetchGraphQL<{ page: Page | null; post: Post | null }>(
-  contentType === "page" ? SINGLE_PAGE_QUERY(slug) : SINGLE_POST_QUERY(slug)
-);
+const [{ inflationIndex, mostRecentYear }, data] = await Promise.all([
+  buildInflationIndex(),
+  fetchGraphQL<{ page: Page | null; post: Post | null }>(
+    contentType === "page" ? SINGLE_PAGE_QUERY(slug) : SINGLE_POST_QUERY(slug)
+  ),
+]);
 
 const singlePost = contentType === "page" ? data.page : data.post;
 


### PR DESCRIPTION
## Summary
- `buildInflationIndex()` and `fetchGraphQL()` in `src/pages/[slug].astro` were awaited sequentially even though neither depends on the other's result.
- Wraps both in `Promise.all` so they run concurrently.

Note: `buildInflationIndex()` is cached at the module level, so this speeds up the first slug page rendered per build worker; subsequent pages already skip the inflation fetch.

Closes #565

## Test plan
- [x] `yarn astro check` — 0 errors
