### PR TITLE
perf: move randomized homepage sections to a client-fetched island

### DIFF
--- a/src/lib/homepage-highlights.test.ts
+++ b/src/lib/homepage-highlights.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const fetchGraphQLMock = vi.fn();
+
+vi.mock("./api", () => ({
+  fetchGraphQL: fetchGraphQLMock,
+}));
+
+const createFeaturedImageNode = (homepageUrl: string, sourceUrl: string = homepageUrl) => ({
+  node: {
+    sourceUrl,
+    mediaDetails: {
+      sizes: [{ name: "homepage", sourceUrl: homepageUrl }],
+    },
+  },
+});
+
+const getDefaultResponseByQuery = (query: string, variables: Record<string, unknown> = {}) => {
+  if (query.includes('where: {tag: "best"}')) {
+    return {
+      posts: {
+        nodes: [
+          {
+            slug: "best-roast",
+            title: "Best Roast",
+            featuredImage: createFeaturedImageNode("https://example.com/best-homepage.jpg"),
+            ratings: { nodes: [{ name: "9.1" }] },
+            yearsOfVisit: { nodes: [{ name: "2025" }] },
+          },
+        ],
+      },
+    };
+  }
+
+  if (query.includes("pages(first: 100)")) {
+    return {
+      pages: {
+        nodes: [
+          {
+            id: "feature-page-1",
+            slug: "feature-page-1",
+            title: "Feature Page 1",
+            highlights: { tag: "feature" },
+            featuredImage: createFeaturedImageNode("https://example.com/feature-page-1.jpg"),
+          },
+          {
+            id: "roastatistics-page-1",
+            slug: "roastatistics-page-1",
+            title: "Roastatistics Page 1",
+            highlights: { tag: "roastatistics" },
+            featuredImage: createFeaturedImageNode("https://example.com/roastatistics-page-1.jpg"),
+          },
+        ],
+      },
+    };
+  }
+
+  if (query.includes('where: {tag: "feature"}')) {
+    return {
+      posts: {
+        edges: [
+          {
+            node: {
+              slug: "feature-post-1",
+              title: "Feature Post 1",
+              featuredImage: createFeaturedImageNode("https://example.com/feature-post-1.jpg"),
+            },
+          },
+        ],
+      },
+    };
+  }
+
+  if (query.includes("query SinglePage($id: ID!)")) {
+    const id = String(variables.id ?? "");
+    return {
+      page: {
+        pageId: id,
+        slug: `page-${id}`,
+        title: `Page ${id}`,
+        featuredImage: createFeaturedImageNode(`https://example.com/page-${id}-homepage.jpg`),
+      },
+    };
+  }
+
+  throw new Error(`Unhandled query in test mock: ${query.slice(0, 60)}`);
+};
+
+beforeEach(() => {
+  fetchGraphQLMock.mockReset();
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
+});
+
+describe("getHomepageHighlights", () => {
+  test("returns best roasts, features, and roastatistics from GraphQL data", async () => {
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) =>
+        getDefaultResponseByQuery(query, variables)
+    );
+
+    const { getHomepageHighlights } = await import("./homepage-highlights");
+    const data = await getHomepageHighlights();
+
+    expect(data.bestRoasts).toEqual([
+      {
+        slug: "best-roast",
+        title: "Best Roast",
+        featuredImageUrl: "https://example.com/best-homepage.jpg",
+        rating: "9.1",
+        yearVisited: "2025",
+      },
+    ]);
+
+    expect(data.features.map((item) => item.slug)).toEqual(
+      expect.arrayContaining(["feature-page-1", "feature-post-1"])
+    );
+
+    expect(data.roastStatistics[0]).toEqual({
+      slug: "page-4102",
+      title: "Page 4102",
+      featuredImageUrl: "https://example.com/page-4102-homepage.jpg",
+    });
+    expect(data.roastStatistics.map((item) => item.slug)).toContain("roastatistics-page-1");
+  });
+
+  test("logs and continues when fetching best roasts fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) => {
+        if (query.includes('where: {tag: "best"}')) {
+          throw new Error("Best roasts request failed");
+        }
+
+        return getDefaultResponseByQuery(query, variables);
+      }
+    );
+
+    const { getHomepageHighlights } = await import("./homepage-highlights");
+    const data = await getHomepageHighlights();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error fetching best roasts:",
+      expect.any(Error)
+    );
+    expect(data.bestRoasts).toEqual([]);
+  });
+
+  test("logs and continues when the all-pages query fails, but feature posts still load", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) => {
+        if (query.includes("pages(first: 100)")) {
+          throw new Error("All pages request failed");
+        }
+
+        return getDefaultResponseByQuery(query, variables);
+      }
+    );
+
+    const { getHomepageHighlights } = await import("./homepage-highlights");
+    const data = await getHomepageHighlights();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error fetching features data:",
+      expect.any(Error)
+    );
+    expect(data.features.map((item) => item.slug)).toEqual(["feature-post-1"]);
+    expect(data.roastStatistics.map((item) => item.slug)).toEqual(["page-4102"]);
+  });
+
+  test("logs and continues when the roastatistics single-page fetch fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) => {
+        if (query.includes("query SinglePage($id: ID!)") && variables.id === "4102") {
+          throw new Error("Roastatistics featured page failed");
+        }
+
+        return getDefaultResponseByQuery(query, variables);
+      }
+    );
+
+    const { getHomepageHighlights } = await import("./homepage-highlights");
+    const data = await getHomepageHighlights();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error fetching features data:",
+      expect.any(Error)
+    );
+    expect(data.roastStatistics.map((item) => item.slug)).toEqual(["roastatistics-page-1"]);
+  });
+
+  test("sanitizes titles containing HTML", async () => {
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) => {
+        if (query.includes('where: {tag: "best"}')) {
+          return {
+            posts: {
+              nodes: [
+                {
+                  slug: "best-roast",
+                  title: "<strong>Best</strong> Roast &amp; Chips",
+                  featuredImage: createFeaturedImageNode("https://example.com/best-homepage.jpg"),
+                  ratings: { nodes: [{ name: "9.1" }] },
+                  yearsOfVisit: { nodes: [{ name: "2025" }] },
+                },
+              ],
+            },
+          };
+        }
+
+        return getDefaultResponseByQuery(query, variables);
+      }
+    );
+
+    const { getHomepageHighlights } = await import("./homepage-highlights");
+    const data = await getHomepageHighlights();
+
+    expect(data.bestRoasts[0].title).not.toContain("<strong>");
+  });
+});

--- a/src/lib/homepage-highlights.ts
+++ b/src/lib/homepage-highlights.ts
@@ -1,0 +1,159 @@
+import type { Page, Post, Size } from "../types";
+import { fetchGraphQL } from "./api";
+import GET_BEST_ROASTS from "./queries/bestRoasts";
+import GET_ALL_PAGES from "./queries/getAllPages";
+import GET_FEATURE_POSTS from "./queries/getFeaturePosts.ts";
+import SINGLE_PAGE_QUERY_PREVIEW from "./queries/singlePage";
+import { sanitizeTitle } from "./sanitize";
+
+export type HighlightItem = {
+  slug: string;
+  title: string;
+  featuredImageUrl?: string;
+};
+
+export type BestRoastHighlight = HighlightItem & {
+  rating?: string;
+  yearVisited?: string;
+};
+
+export type HomepageHighlights = {
+  bestRoasts: BestRoastHighlight[];
+  features: HighlightItem[];
+  roastStatistics: HighlightItem[];
+};
+
+const toHighlight = (item: {
+  slug?: string;
+  title?: string;
+  featuredImageUrl?: string;
+}): HighlightItem => ({
+  slug: item.slug ?? "",
+  title: sanitizeTitle(item.title),
+  featuredImageUrl: item.featuredImageUrl,
+});
+
+const fetchBestRoasts = async (): Promise<BestRoastHighlight[]> => {
+  try {
+    const response = (await fetchGraphQL(GET_BEST_ROASTS)) as {
+      posts: { nodes: Post[] };
+    };
+    const bestRoasts = response?.posts?.nodes
+      ?.map((post: Post) => {
+        const featuredImage = post.featuredImage?.node;
+        const smallImage =
+          featuredImage?.mediaDetails?.sizes.find(
+            (size: Size) => size.name === "homepage"
+          )?.sourceUrl || featuredImage?.sourceUrl;
+
+        return {
+          ...toHighlight({ slug: post.slug, title: post.title, featuredImageUrl: smallImage }),
+          rating: post.ratings?.nodes?.[0]?.name,
+          yearVisited: post.yearsOfVisit?.nodes?.[0]?.name,
+        };
+      })
+      .filter(Boolean) as BestRoastHighlight[];
+    return bestRoasts.sort(() => Math.random() - 0.5).slice(0, 4);
+  } catch (error) {
+    console.error("Error fetching best roasts:", error);
+    return [];
+  }
+};
+
+const fetchAllPagesData = async (): Promise<{
+  pageFeatures: HighlightItem[];
+  roastStatistics: HighlightItem[];
+}> => {
+  try {
+    const response = (await fetchGraphQL(GET_ALL_PAGES)) as {
+      pages: { nodes: Page[] };
+    };
+    const pages = response?.pages?.nodes ?? [];
+
+    const toPageHighlight = (page: Page): HighlightItem => {
+      const featuredImage = page.featuredImage?.node;
+      const smallImage =
+        featuredImage?.mediaDetails?.sizes.find((size: Size) => size.name === "homepage")
+          ?.sourceUrl || featuredImage?.sourceUrl;
+
+      return toHighlight({ slug: page.slug, title: page.title, featuredImageUrl: smallImage });
+    };
+
+    const pageFeatures = pages
+      .filter((page: Page) => page?.highlights?.tag === "feature")
+      .map(toPageHighlight);
+
+    const roastStatistics = pages
+      .filter((page: Page) => page?.highlights?.tag === "roastatistics")
+      .map(toPageHighlight);
+
+    return { pageFeatures, roastStatistics };
+  } catch (error) {
+    console.error("Error fetching features data:", error);
+    return { pageFeatures: [], roastStatistics: [] };
+  }
+};
+
+const fetchFeaturePosts = async (): Promise<HighlightItem[]> => {
+  try {
+    const postsResponse = (await fetchGraphQL(GET_FEATURE_POSTS)) as {
+      posts: { edges: Array<{ node: Post }> };
+    };
+
+    return postsResponse.posts.edges.map(({ node }) => {
+      const featuredImageUrl =
+        node.featuredImage?.node?.mediaDetails?.sizes?.find(
+          (size: Size) => size.name === "homepage"
+        )?.sourceUrl || node.featuredImage?.node?.sourceUrl;
+
+      return toHighlight({ slug: node.slug, title: node.title, featuredImageUrl });
+    });
+  } catch (error) {
+    console.error("Error fetching feature posts:", error);
+    return [];
+  }
+};
+
+const fetchRoastStatsSinglePage = async (): Promise<HighlightItem | null> => {
+  try {
+    const response = (await fetchGraphQL(SINGLE_PAGE_QUERY_PREVIEW, {
+      id: "4102",
+    })) as { page: Page | null };
+
+    if (!response?.page) return null;
+
+    const featuredImageUrl =
+      response.page.featuredImage?.node?.mediaDetails?.sizes?.find(
+        (size: Size) => size.name === "homepage"
+      )?.sourceUrl || response.page.featuredImage?.node?.sourceUrl;
+
+    return toHighlight({
+      slug: response.page.slug,
+      title: response.page.title,
+      featuredImageUrl,
+    });
+  } catch (error) {
+    console.error("Error fetching features data:", error);
+    return null;
+  }
+};
+
+export const getHomepageHighlights = async (): Promise<HomepageHighlights> => {
+  const [bestRoasts, allPagesData, featurePosts, roastStatsSinglePage] = await Promise.all([
+    fetchBestRoasts(),
+    fetchAllPagesData(),
+    fetchFeaturePosts(),
+    fetchRoastStatsSinglePage(),
+  ]);
+
+  let features: HighlightItem[] = [...allPagesData.pageFeatures, ...featurePosts];
+  features = features.sort(() => Math.random() - 0.5).slice(0, 4);
+
+  const roastStatistics = allPagesData.roastStatistics.sort(() => Math.random() - 0.5).slice(0, 3);
+
+  if (roastStatsSinglePage) {
+    roastStatistics.unshift(roastStatsSinglePage);
+  }
+
+  return { bestRoasts, features, roastStatistics };
+};

--- a/src/pages/api/homepage-highlights.json.test.ts
+++ b/src/pages/api/homepage-highlights.json.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from "vitest";
+
+const getHomepageHighlightsMock = vi.fn();
+
+vi.mock("../../lib/homepage-highlights", () => ({
+  getHomepageHighlights: getHomepageHighlightsMock,
+}));
+
+describe("GET /api/homepage-highlights.json", () => {
+  test("returns the homepage highlights as JSON", async () => {
+    const highlights = {
+      bestRoasts: [{ slug: "best-roast", title: "Best Roast" }],
+      features: [{ slug: "feature-1", title: "Feature 1" }],
+      roastStatistics: [{ slug: "page-4102", title: "Page 4102" }],
+    };
+    getHomepageHighlightsMock.mockResolvedValue(highlights);
+
+    const { GET } = await import("./homepage-highlights.json");
+    const response = await GET({} as never);
+
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    const data = await response.json();
+    expect(data).toEqual(highlights);
+  });
+});

--- a/src/pages/api/homepage-highlights.json.ts
+++ b/src/pages/api/homepage-highlights.json.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro";
+import { getHomepageHighlights } from "../../lib/homepage-highlights";
+
+export const GET: APIRoute = async () => {
+  const data = await getHomepageHighlights();
+
+  return new Response(JSON.stringify(data), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,15 +10,11 @@ import dreamingOfRoastDinners from "../images/dreaming of roast dinners.png";
 import findARoastImg from "../images/find-a-roast.png";
 import guessTheScoreImg from "../images/guess-the-score.png";
 import { fetchGraphQL } from "../lib/api";
-import GET_BEST_ROASTS from "../lib/queries/bestRoasts";
-import GET_ALL_PAGES from "../lib/queries/getAllPages";
-import GET_FEATURE_POSTS from "../lib/queries/getFeaturePosts.ts";
 import MOST_RECENT_POST_QUERY from "../lib/queries/mostRecentPost";
 import OTHER_POSTS_AFTER_FIRST_QUERY from "../lib/queries/otherPostsAfterFirst";
 import SINGLE_PAGE_QUERY_PREVIEW from "../lib/queries/singlePage";
 import type { Page, Post, Size } from "../types";
 
-type PostWithFeaturedImage = Post & { featuredImage: string };
 type PageWithFeaturedImage = Page & { featuredImage: string };
 
 let recentPost: Post | null = null;
@@ -130,151 +126,10 @@ const fetchFindYourFavouriteRoastPages = async (): Promise<PageWithFeaturedImage
   }
 };
 
-const fetchBestRoasts = async (): Promise<Post[]> => {
-  try {
-    const response = (await fetchGraphQL(GET_BEST_ROASTS)) as {
-      posts: { nodes: Post[] };
-    };
-    const bestRoasts = response?.posts?.nodes
-      ?.map((post: Post) => {
-        const featuredImage = post.featuredImage?.node;
-        const smallImage =
-          featuredImage?.mediaDetails?.sizes.find(
-            (size: Size) => size.name === "homepage"
-          )?.sourceUrl || featuredImage?.sourceUrl;
-
-        return {
-          ...post,
-          featuredImageUrl: smallImage,
-        };
-      })
-      .filter(Boolean);
-    return bestRoasts.sort(() => Math.random() - 0.5).slice(0, 4);
-  } catch (error) {
-    console.error("Error fetching best roasts:", error);
-    return [];
-  }
-};
-
-const fetchAllPagesData = async (): Promise<{
-  pageFeatures: PageWithFeaturedImage[];
-  roastStatistics: PageWithFeaturedImage[];
-}> => {
-  try {
-    const response = (await fetchGraphQL(GET_ALL_PAGES)) as {
-      pages: { nodes: Page[] };
-    };
-    const allPages = response?.pages?.nodes
-      ?.map((page: Page) => {
-        const featuredImage = page.featuredImage?.node;
-        const smallImage =
-          featuredImage?.mediaDetails?.sizes.find(
-            (size: Size) => size.name === "homepage"
-          )?.sourceUrl || featuredImage?.sourceUrl;
-
-        return {
-          ...page,
-          featuredImageUrl: smallImage,
-        };
-      })
-      .filter(Boolean);
-
-    const allFeaturesPages = allPages.filter(
-      (page: Page) => page?.highlights?.tag === "feature"
-    );
-    const allRoastStatisticsPages = allPages.filter(
-      (page: Page) => page?.highlights?.tag === "roastatistics"
-    );
-
-    const pageFeatures = allFeaturesPages.map((page: Page) => {
-      const featuredImage = page.featuredImage?.node?.sourceUrl || "";
-      return {
-        ...page,
-        featuredImage,
-      } as PageWithFeaturedImage;
-    });
-
-    const roastStatistics = allRoastStatisticsPages.map((page: Page) => {
-      const featuredImage = page.featuredImage?.node?.sourceUrl || "";
-      return {
-        ...page,
-        featuredImage,
-      } as PageWithFeaturedImage;
-    });
-
-    return { pageFeatures, roastStatistics };
-  } catch (error) {
-    console.error("Error fetching features data:", error);
-    return { pageFeatures: [], roastStatistics: [] };
-  }
-};
-
-const fetchFeaturePosts = async (): Promise<PostWithFeaturedImage[]> => {
-  try {
-    const postsResponse = (await fetchGraphQL(GET_FEATURE_POSTS)) as {
-      posts: { edges: Array<{ node: Post }> };
-    };
-
-    return postsResponse.posts.edges.map((edge: { node: Post }) => ({
-      ...edge.node,
-      featuredImageUrl:
-        edge.node.featuredImage?.node?.mediaDetails?.sizes?.find(
-          (size: Size) => size.name === "homepage"
-        )?.sourceUrl || edge.node.featuredImage?.node?.sourceUrl,
-    })) as unknown as PostWithFeaturedImage[];
-  } catch (error) {
-    console.error("Error fetching feature posts:", error);
-    return [];
-  }
-};
-
-const fetchRoastStatsSinglePage = async (): Promise<PageWithFeaturedImage | null> => {
-  try {
-    const response = (await fetchGraphQL(SINGLE_PAGE_QUERY_PREVIEW, {
-      id: "4102",
-    })) as { page: Page };
-    return {
-      ...response.page,
-      featuredImageUrl:
-        response.page.featuredImage?.node?.mediaDetails?.sizes?.find(
-          (size: Size) => size.name === "homepage"
-        )?.sourceUrl || response.page.featuredImage?.node?.sourceUrl,
-    } as PageWithFeaturedImage;
-  } catch (error) {
-    console.error("Error fetching features data:", error);
-    return null;
-  }
-};
-
-const [
-  locationPages,
-  findYourFavouriteRoastPages,
-  bestRoasts,
-  allPagesData,
-  featurePosts,
-  roastStatsSinglePage,
-] = await Promise.all([
+const [locationPages, findYourFavouriteRoastPages] = await Promise.all([
   fetchLocationPages(),
   fetchFindYourFavouriteRoastPages(),
-  fetchBestRoasts(),
-  fetchAllPagesData(),
-  fetchFeaturePosts(),
-  fetchRoastStatsSinglePage(),
 ]);
-
-let features: Array<PostWithFeaturedImage | PageWithFeaturedImage> = [
-  ...allPagesData.pageFeatures,
-  ...featurePosts,
-];
-features = features.sort(() => Math.random() - 0.5).slice(0, 4);
-
-const roastStatistics: Array<PageWithFeaturedImage> = allPagesData.roastStatistics
-  .sort(() => Math.random() - 0.5)
-  .slice(0, 3);
-
-if (roastStatsSinglePage) {
-  roastStatistics.unshift(roastStatsSinglePage);
-}
 ---
 
 <BaseLayout
@@ -423,103 +278,113 @@ if (roastStatsSinglePage) {
     <h2 id="search-heading">Search:</h2>
     <Search resultLimit={4} />
   </section>
-  <section class="home-list" aria-labelledby="best-roasts-heading">
-    <h2 id="best-roasts-heading">A few of the best roasts:</h2>
-    <ul>
-      {
-        bestRoasts.map((post, index) => (
+  <div x-data="homepageHighlights">
+    <section class="home-list" aria-labelledby="best-roasts-heading">
+      <h2 id="best-roasts-heading">A few of the best roasts:</h2>
+      <ul class="highlights-list">
+        <template x-for="(post, index) in bestRoasts" :key="post.slug">
           <li class="heading">
             <h3>
-              <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={sanitizeTitle(post?.title)} />
-              </a>
+              <a :href="`/${post.slug}`" rel="noopener noreferrer" x-text="post.title"></a>
             </h3>
             <a
-              href={`/${post?.slug}`}
+              :href="`/${post.slug}`"
               rel="noopener noreferrer"
               class="featured-image"
               aria-hidden="true"
               tabindex="-1"
             >
               <img
-                src={post?.featuredImageUrl}
-                alt={`Photo of the roast dinner at ${post?.title}`}
+                :src="post.featuredImageUrl"
+                :alt="`Photo of the roast dinner at ${post.title}`"
                 width="400"
                 height="300"
-                loading={index === 0 ? "eager" : "lazy"}
+                :loading="index === 0 ? 'eager' : 'lazy'"
               />
             </a>
-            <p>Rating: {post?.ratings?.nodes[0]?.name}</p>
-            <p>Year Visited: {post?.yearsOfVisit?.nodes[0]?.name}</p>
+            <p x-text="`Rating: ${post.rating ?? ''}`"></p>
+            <p x-text="`Year Visited: ${post.yearVisited ?? ''}`"></p>
           </li>
-        ))
-      }
-    </ul>
-  </section>
-  <section class="home-list" aria-labelledby="features-heading">
-    <h2 id="features-heading">Features:</h2>
-    <ul>
-      {
-        features.map((post, index) => (
+        </template>
+      </ul>
+    </section>
+    <section class="home-list" aria-labelledby="features-heading">
+      <h2 id="features-heading">Features:</h2>
+      <ul class="highlights-list">
+        <template x-for="(post, index) in features" :key="post.slug">
           <li class="heading">
             <h3>
-              <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={sanitizeTitle(post?.title)} />
-              </a>
+              <a :href="`/${post.slug}`" rel="noopener noreferrer" x-text="post.title"></a>
             </h3>
             <a
-              href={`/${post?.slug}`}
+              :href="`/${post.slug}`"
               rel="noopener noreferrer"
               class="featured-image"
               aria-hidden="true"
               tabindex="-1"
             >
               <img
-                src={post?.featuredImageUrl}
-                alt={`Preview image for ${post?.title}`}
+                :src="post.featuredImageUrl"
+                :alt="`Preview image for ${post.title}`"
                 width="400"
                 height="300"
-                loading={index === 0 ? "eager" : "lazy"}
+                :loading="index === 0 ? 'eager' : 'lazy'"
               />
             </a>
           </li>
-        ))
-      }
-    </ul>
-  </section>
-  <section class="home-list" aria-labelledby="roastatistics-heading">
-    <h2 id="roastatistics-heading">Roastatistics:</h2>
-    <ul>
-      {
-        roastStatistics.map((post, index) => (
+        </template>
+      </ul>
+    </section>
+    <section class="home-list" aria-labelledby="roastatistics-heading">
+      <h2 id="roastatistics-heading">Roastatistics:</h2>
+      <ul class="highlights-list">
+        <template x-for="(post, index) in roastStatistics" :key="post.slug">
           <li class="heading">
             <h3>
-              <a href={`/${post?.slug}`} rel="noopener noreferrer">
-                <Fragment set:html={sanitizeTitle(post?.title)} />
-              </a>
+              <a :href="`/${post.slug}`" rel="noopener noreferrer" x-text="post.title"></a>
             </h3>
             <a
-              href={`/${post?.slug}`}
+              :href="`/${post.slug}`"
               rel="noopener noreferrer"
               class="featured-image"
               aria-hidden="true"
               tabindex="-1"
             >
               <img
-                src={post?.featuredImageUrl}
-                alt={`Preview image for ${post?.title}`}
+                :src="post.featuredImageUrl"
+                :alt="`Preview image for ${post.title}`"
                 width="400"
                 height="300"
-                loading={index === 0 ? "eager" : "lazy"}
+                :loading="index === 0 ? 'eager' : 'lazy'"
               />
             </a>
           </li>
-        ))
-      }
-    </ul>
-  </section>
+        </template>
+      </ul>
+    </section>
+  </div>
   <Newsletter />
   <NewsletterPopup />
+  <script is:inline>
+    document.addEventListener("alpine:init", () => {
+      Alpine.data("homepageHighlights", () => ({
+        bestRoasts: [],
+        features: [],
+        roastStatistics: [],
+        async init() {
+          try {
+            const response = await fetch("/api/homepage-highlights.json");
+            const data = await response.json();
+            this.bestRoasts = data.bestRoasts || [];
+            this.features = data.features || [];
+            this.roastStatistics = data.roastStatistics || [];
+          } catch (error) {
+            console.error("Error fetching homepage highlights:", error);
+          }
+        },
+      }));
+    });
+  </script>
   <script lang="ts">
     document.addEventListener("DOMContentLoaded", function () {
       const dropdownButton = document.getElementById("dropdown-btn");

--- a/src/pages/index.test.ts
+++ b/src/pages/index.test.ts
@@ -79,61 +79,6 @@ const getDefaultResponseByQuery = (query: string, variables: Record<string, unkn
     };
   }
 
-  if (query.includes("where: {tag: \"best\"}")) {
-    return {
-      posts: {
-        nodes: [
-          {
-            slug: "best-roast",
-            title: "Best Roast",
-            featuredImage: createFeaturedImageNode("https://example.com/best-homepage.jpg"),
-            ratings: { nodes: [{ name: "9.1" }] },
-            yearsOfVisit: { nodes: [{ name: "2025" }] },
-          },
-        ],
-      },
-    };
-  }
-
-  if (query.includes("pages(first: 100)")) {
-    return {
-      pages: {
-        nodes: [
-          {
-            id: "feature-page-1",
-            slug: "feature-page-1",
-            title: "Feature Page 1",
-            highlights: { tag: "feature" },
-            featuredImage: createFeaturedImageNode("https://example.com/feature-page-1.jpg"),
-          },
-          {
-            id: "roastatistics-page-1",
-            slug: "roastatistics-page-1",
-            title: "Roastatistics Page 1",
-            highlights: { tag: "roastatistics" },
-            featuredImage: createFeaturedImageNode("https://example.com/roastatistics-page-1.jpg"),
-          },
-        ],
-      },
-    };
-  }
-
-  if (query.includes("where: {tag: \"feature\"}")) {
-    return {
-      posts: {
-        edges: [
-          {
-            node: {
-              slug: "feature-post-1",
-              title: "Feature Post 1",
-              featuredImage: createFeaturedImageNode("https://example.com/feature-post-1.jpg"),
-            },
-          },
-        ],
-      },
-    };
-  }
-
   throw new Error(`Unhandled query in test mock: ${query.slice(0, 60)}`);
 };
 
@@ -160,7 +105,7 @@ describe("index page", () => {
     const { default: Page } = await import("./index.astro");
     const html = await container.renderToString(Page);
 
-    expect(fetchGraphQLMock).toHaveBeenCalledTimes(14);
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(10);
     expect(fetchGraphQLMock).toHaveBeenCalledWith(expect.stringContaining("GetOtherPosts"), {
       after: "cursor-1",
     });
@@ -168,7 +113,7 @@ describe("index page", () => {
       id: "5614",
     });
     expect(fetchGraphQLMock).toHaveBeenCalledWith(expect.stringContaining("SinglePage"), {
-      id: "4102",
+      id: "267",
     });
 
     expect(html).toContain("Latest Reviews:");
@@ -176,14 +121,16 @@ describe("index page", () => {
     expect(html).toContain("Other Roast");
     expect(html).toContain("Find Your Favourite Roast:");
     expect(html).toContain("Roast By Location:");
-    expect(html).toContain("A few of the best roasts:");
-    expect(html).toContain("Best Roast");
-    expect(html).toContain("Rating: 9.1");
-    expect(html).toContain("Year Visited: 2025");
-    expect(html).toContain("Features:");
-    expect(html).toContain("Roastatistics:");
     expect(html).toContain("Search:");
     expect(html).toContain("data-result-limit=\"4\"");
+
+    expect(html).toContain("A few of the best roasts:");
+    expect(html).toContain("Features:");
+    expect(html).toContain("Roastatistics:");
+    expect(html).toContain('x-data="homepageHighlights"');
+    expect(html).toContain("/api/homepage-highlights.json");
+
+    expect(html).not.toContain("Page 4102");
   });
 
   test("continues to render remaining sections when most recent post query fails", async () => {
@@ -204,7 +151,7 @@ describe("index page", () => {
     const { default: Page } = await import("./index.astro");
     const html = await container.renderToString(Page);
 
-    expect(fetchGraphQLMock).toHaveBeenCalledTimes(13);
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(9);
     expect(fetchGraphQLMock).not.toHaveBeenCalledWith(expect.stringContaining("GetOtherPosts"), {
       after: "cursor-1",
     });
@@ -217,7 +164,6 @@ describe("index page", () => {
     expect(html).toContain("Find Your Favourite Roast:");
     expect(html).toContain("Roast By Location:");
     expect(html).toContain("Search:");
-    expect(html).toContain("A few of the best roasts:");
   });
 
   test("renders remaining content when most recent query returns no posts", async () => {
@@ -245,14 +191,13 @@ describe("index page", () => {
     const { default: Page } = await import("./index.astro");
     const html = await container.renderToString(Page);
 
-    expect(fetchGraphQLMock).toHaveBeenCalledTimes(13);
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(9);
     expect(fetchGraphQLMock).not.toHaveBeenCalledWith(expect.stringContaining("GetOtherPosts"), {
       after: "cursor-1",
     });
     expect(html).toContain("Latest Reviews:");
     expect(html).toContain("Find Your Favourite Roast:");
     expect(html).toContain("Roast By Location:");
-    expect(html).toContain("A few of the best roasts:");
     expect(html).toContain("Search:");
     expect(consoleErrorSpy).not.toHaveBeenCalledWith(
       "Error fetching the most recent post:",
@@ -319,14 +264,13 @@ describe("index page", () => {
     const { default: Page } = await import("./index.astro");
     const html = await container.renderToString(Page);
 
-    expect(fetchGraphQLMock).toHaveBeenCalledTimes(14);
+    expect(fetchGraphQLMock).toHaveBeenCalledTimes(10);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Error fetching other posts:",
       expect.any(Error)
     );
     expect(html).toContain("Latest Roast");
     expect(html).not.toContain("Other Roast");
-    expect(html).toContain("A few of the best roasts:");
   });
 
   test("uses most recent post sourceUrl when homepage image size is missing", async () => {
@@ -514,84 +458,6 @@ describe("index page", () => {
     expect(html).toContain("Roast By Location:");
   });
 
-  test("logs and continues when fetching best roasts fails", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("where: {tag: \"best\"}")) {
-          throw new Error("Best roasts request failed");
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error fetching best roasts:",
-      expect.any(Error)
-    );
-    expect(html).toContain("A few of the best roasts:");
-    expect(html).not.toContain("Rating: 9.1");
-  });
-
-  test("logs and continues when features pages query fails", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("pages(first: 100)")) {
-          throw new Error("All pages request failed");
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error fetching features data:",
-      expect.any(Error)
-    );
-    expect(html).toContain("Features:");
-    expect(html).toContain("Feature Post 1");
-  });
-
-  test("logs and continues when roastatistics single page fetch fails", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("query SinglePage($id: ID!)") && variables.id === "4102") {
-          throw new Error("Roastatistics featured page failed");
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error fetching features data:",
-      expect.any(Error)
-    );
-    expect(html).toContain("Roastatistics:");
-    expect(html).not.toContain("Page 4102");
-  });
-
   test("uses favourite roast page sourceUrl when homepage image size is missing", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5);
 
@@ -626,167 +492,4 @@ describe("index page", () => {
     expect(html).toContain("Find Your Favourite Roast:");
     expect(html).toContain('src="https://example.com/favourite-fallback-source.jpg"');
   });
-
-  test("uses best roast sourceUrl when homepage image size is missing", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("where: {tag: \"best\"}")) {
-          return {
-            posts: {
-              nodes: [
-                {
-                  slug: "best-roast-fallback",
-                  title: "Best Roast Fallback",
-                  featuredImage: {
-                    node: {
-                      sourceUrl: "https://example.com/best-fallback-source.jpg",
-                      mediaDetails: {
-                        sizes: [{ name: "thumbnail", sourceUrl: "https://example.com/best-thumb.jpg" }],
-                      },
-                    },
-                  },
-                  ratings: { nodes: [{ name: "8.8" }] },
-                  yearsOfVisit: { nodes: [{ name: "2024" }] },
-                },
-              ],
-            },
-          };
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(html).toContain("Best Roast Fallback");
-    expect(html).toContain('src="https://example.com/best-fallback-source.jpg"');
-  });
-
-  test("uses feature post sourceUrl when homepage image size is missing", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("where: {tag: \"feature\"}")) {
-          return {
-            posts: {
-              edges: [
-                {
-                  node: {
-                    slug: "feature-post-fallback",
-                    title: "Feature Post Fallback",
-                    featuredImage: {
-                      node: {
-                        sourceUrl: "https://example.com/feature-post-fallback-source.jpg",
-                        mediaDetails: {
-                          sizes: [
-                            { name: "thumbnail", sourceUrl: "https://example.com/feature-post-thumb.jpg" },
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
-              ],
-            },
-          };
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(html).toContain("Feature Post Fallback");
-    expect(html).toContain('src="https://example.com/feature-post-fallback-source.jpg"');
-  });
-
-  test("uses all pages sourceUrl when homepage image size is missing", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("pages(first: 100)")) {
-          return {
-            pages: {
-              nodes: [
-                {
-                  id: "feature-page-fallback",
-                  slug: "feature-page-fallback",
-                  title: "Feature Page Fallback",
-                  highlights: { tag: "feature" },
-                  featuredImage: {
-                    node: {
-                      sourceUrl: "https://example.com/all-pages-fallback-source.jpg",
-                      mediaDetails: {
-                        sizes: [
-                          { name: "thumbnail", sourceUrl: "https://example.com/all-pages-thumb.jpg" },
-                        ],
-                      },
-                    },
-                  },
-                },
-              ],
-            },
-          };
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(html).toContain("Feature Page Fallback");
-    expect(html).toContain('src="https://example.com/all-pages-fallback-source.jpg"');
-  });
-
-  test("uses roastatistics single-page sourceUrl when homepage image size is missing", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    fetchGraphQLMock.mockImplementation(
-      async (query: string, variables: Record<string, unknown> = {}) => {
-        if (query.includes("query SinglePage($id: ID!)") && variables.id === "4102") {
-          return {
-            page: {
-              pageId: "4102",
-              slug: "page-4102",
-              title: "Page 4102",
-              featuredImage: {
-                node: {
-                  sourceUrl: "https://example.com/roastatistics-fallback-source.jpg",
-                  mediaDetails: {
-                    sizes: [
-                      { name: "thumbnail", sourceUrl: "https://example.com/roastatistics-thumb.jpg" },
-                    ],
-                  },
-                },
-              },
-            },
-          };
-        }
-
-        return getDefaultResponseByQuery(query, variables);
-      }
-    );
-
-    const container = await AstroContainer.create();
-    const { default: Page } = await import("./index.astro");
-    const html = await container.renderToString(Page);
-
-    expect(html).toContain("Roastatistics:");
-    expect(html).toContain("Page 4102");
-    expect(html).toContain('src="https://example.com/roastatistics-fallback-source.jpg"');
-  });
-
 });

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -160,6 +160,10 @@ section {
   }
 }
 
+.home-list ul.highlights-list {
+  min-height: 340px;
+}
+
 .custom-select {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Best roasts, features, and roastatistics are the only genuinely random parts of the homepage (reshuffled via Math.random() on every load), so they're moved out of SSR into a new /api/homepage-highlights.json endpoint fetched client-side via Alpine after the page loads. This drops the homepage's blocking server-side fetch count from 7 groups to 2 (recent post cursor chain + location/favourite-roast pages in parallel), while keeping the randomness per-request since the endpoint itself still runs server-side per request.

The three sections are below the fold, so the brief empty-then-populated state is an acceptable trade for faster initial paint; a min-height on .highlights-list keeps the layout shift small in the meantime.

Also extracts the highlights-fetching logic into src/lib/homepage-highlights.ts, which fixes a latent bug: GET_FEATURE_POSTS was previously coupled to GET_ALL_PAGES's try/catch, so an all-pages failure silently dropped feature posts too even though they're an independent query.