### PR TITLE
Exclude closed down pubs from home page "best roasts" section

### DIFF
--- a/src/lib/queries/bestRoasts.ts
+++ b/src/lib/queries/bestRoasts.ts
@@ -25,6 +25,11 @@ const GET_BEST_ROASTS = `
             name
           }
         }
+        closedDowns {
+          nodes {
+            name
+          }
+        }
       }
     }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -148,7 +148,8 @@ const fetchBestRoasts = async (): Promise<Post[]> => {
           featuredImageUrl: smallImage,
         };
       })
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter((post: Post) => (post.closedDowns?.nodes?.length ?? 0) === 0);
     return bestRoasts.sort(() => Math.random() - 0.5).slice(0, 4);
   } catch (error) {
     console.error("Error fetching best roasts:", error);

--- a/src/pages/index.test.ts
+++ b/src/pages/index.test.ts
@@ -667,6 +667,57 @@ describe("index page", () => {
     expect(html).toContain('src="https://example.com/best-fallback-source.jpg"');
   });
 
+  test("excludes closed down pubs from the best roasts section", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    fetchGraphQLMock.mockImplementation(
+      async (query: string, variables: Record<string, unknown> = {}) => {
+        if (query.includes("where: {tag: \"best\"}")) {
+          return {
+            posts: {
+              nodes: [
+                {
+                  slug: "best-roast",
+                  title: "Best Roast",
+                  featuredImage: createFeaturedImageNode("https://example.com/best-homepage.jpg"),
+                  ratings: { nodes: [{ name: "9.1" }] },
+                  yearsOfVisit: { nodes: [{ name: "2025" }] },
+                  closedDowns: { nodes: [] },
+                },
+                {
+                  slug: "closed-down-roast",
+                  title: "Closed Down Roast",
+                  featuredImage: createFeaturedImageNode("https://example.com/closed-homepage.jpg"),
+                  ratings: { nodes: [{ name: "9.5" }] },
+                  yearsOfVisit: { nodes: [{ name: "2024" }] },
+                  closedDowns: { nodes: [{ name: "closeddown" }] },
+                },
+                {
+                  slug: "popup-moved-roast",
+                  title: "Popup Moved Roast",
+                  featuredImage: createFeaturedImageNode("https://example.com/popup-homepage.jpg"),
+                  ratings: { nodes: [{ name: "8.0" }] },
+                  yearsOfVisit: { nodes: [{ name: "2023" }] },
+                  closedDowns: { nodes: [{ name: "popupmoved" }] },
+                },
+              ],
+            },
+          };
+        }
+
+        return getDefaultResponseByQuery(query, variables);
+      }
+    );
+
+    const container = await AstroContainer.create();
+    const { default: Page } = await import("./index.astro");
+    const html = await container.renderToString(Page);
+
+    expect(html).toContain("Best Roast");
+    expect(html).not.toContain("Closed Down Roast");
+    expect(html).not.toContain("Popup Moved Roast");
+  });
+
   test("uses feature post sourceUrl when homepage image size is missing", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5);
 


### PR DESCRIPTION
## Summary
- The "a few of the best roasts" section on the home page could previously feature pubs that are closed down, have a popup that has moved, are temporarily closed, etc.
- `closedDowns` is now fetched in the best roasts GraphQL query (`src/lib/queries/bestRoasts.ts`) and any post with a non-empty `closedDowns` taxonomy is filtered out before the random selection in `src/pages/index.astro`, matching the existing "is this post closed" check used elsewhere (e.g. `src/components/roastByTagSection/roast-by-tag-section.astro`, `src/pages/[slug].astro`).

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npx vitest run src/pages/index.test.ts` — 20 passed, including a new test asserting closed-down / popup-moved posts are excluded while open posts still appear

Re-does #570, which was closed due to a stale merge/diff issue on GitHub's side rather than a code problem — rebuilt cleanly from current `main`.
