### PR TITLE
feat: Share My Top Picks button (only when a filter is applied)

### DIFF
--- a/src/components/sort-posts/sort-posts.test.tsx
+++ b/src/components/sort-posts/sort-posts.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Post } from "../../types";
 import SortPosts from "./sort-posts";
 
@@ -737,6 +737,69 @@ describe("sort-posts component", () => {
 
     await forceSort("closedDown");
     expect(getRoastTitles(host)[0]).toBe("Has Everything");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("only shows Share My Top Picks button once a filter is applied", async () => {
+    const { host, root } = createHost();
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await act(async () => {
+      root.render(<SortPosts posts={posts} />);
+    });
+    await waitForRender();
+
+    const showOptionsButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show all options / filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      showOptionsButton.click();
+    });
+    await waitForRender();
+
+    const findShareTopPicksButton = () =>
+      host.querySelector('[data-test-id="share-top-picks-button"]') as HTMLButtonElement | null;
+
+    expect(findShareTopPicksButton()).toBeNull();
+
+    const meatFilter = host.querySelector('select[name="meat"]') as HTMLSelectElement;
+    await act(async () => {
+      meatFilter.value = "Beef";
+      meatFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    const shareTopPicksButton = findShareTopPicksButton();
+    expect(shareTopPicksButton).not.toBeNull();
+
+    await act(async () => {
+      shareTopPicksButton?.click();
+    });
+    await waitForRender();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain("Alpha Arms");
+    expect(findShareTopPicksButton()?.textContent).toBe("Copied!");
+
+    const clearButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Clear All Filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      clearButton.click();
+    });
+    await waitForRender();
+
+    expect(findShareTopPicksButton()).toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/src/components/sort-posts/sort-posts.tsx
+++ b/src/components/sort-posts/sort-posts.tsx
@@ -71,6 +71,9 @@ const SortPosts = ({
     setShowClosedDown,
     copyShareableLink,
     copied,
+    copyFilteredResults,
+    copiedResults,
+    hasActiveFilters,
     setShowInflationPrice,
   } = useSortFilter(posts);
 
@@ -339,6 +342,16 @@ const SortPosts = ({
           <button type="button" className="share-button" onClick={copyShareableLink}>
             {copied ? "Copied!" : "Copy shareable link"}
           </button>
+          {hasActiveFilters && sortedPosts.length > 0 && (
+            <button
+              type="button"
+              className="share-button"
+              data-test-id="share-top-picks-button"
+              onClick={copyFilteredResults}
+            >
+              {copiedResults ? "Copied!" : "Share My Top Picks"}
+            </button>
+          )}
         </div>
       )}
 

--- a/src/components/sort-posts/useSortFilter.tsx
+++ b/src/components/sort-posts/useSortFilter.tsx
@@ -142,6 +142,15 @@ const filterPosts = (posts: Post[], filters: FilterState): Post[] => {
   });
 };
 
+const buildFilterContextLine = (filters: FilterState): string => {
+  const subject = filters.meat ? `Best ${filters.meat}` : "Top Picks";
+  const location = filters.borough || filters.area;
+  const parts = [subject];
+  if (location) parts.push(`in ${location}`);
+  if (filters.score) parts.push(`rated ${filters.score}+`);
+  return parts.join(" ");
+};
+
 export const translateClosedDown = (
   closedDown: string | undefined,
   newSlug: string | undefined
@@ -210,6 +219,9 @@ type UseSortFilterReturn = {
   setShowInflationPrice: BooleanStateSetter;
   copyShareableLink: () => void;
   copied: boolean;
+  copyFilteredResults: () => void;
+  copiedResults: boolean;
+  hasActiveFilters: boolean;
 };
 
 const getInitialStateFromUrl = (): URLSearchParams | null => {
@@ -251,6 +263,7 @@ export const useSortFilter = (posts: Post[]): UseSortFilterReturn => {
   const [showOwner, setShowOwner] = useState(false);
   const [showClosedDown, setShowClosedDown] = useState(true);
   const [copied, setCopied] = useState(false);
+  const [copiedResults, setCopiedResults] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -313,6 +326,24 @@ export const useSortFilter = (posts: Post[]): UseSortFilterReturn => {
     [posts]
   );
 
+  const hasActiveFilters = useMemo(
+    () => Object.values(filters).some((value) => value !== ""),
+    [filters]
+  );
+
+  const copyFilteredResults = useCallback(() => {
+    const contextLine = buildFilterContextLine(filters);
+    const topPicks = sortedPosts
+      .slice(0, 5)
+      .map((post) => `${post.title} ${post.ratings?.nodes[0]?.name ?? ""}/10`)
+      .join(" | ");
+    const text = `${contextLine} — ${topPicks} | ${window.location.href}`;
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedResults(true);
+      setTimeout(() => setCopiedResults(false), 2000);
+    });
+  }, [filters, sortedPosts]);
+
   return {
     sortOrder,
     sortColumn,
@@ -344,6 +375,9 @@ export const useSortFilter = (posts: Post[]): UseSortFilterReturn => {
     setShowClosedDown,
     copyShareableLink,
     copied,
+    copyFilteredResults,
+    copiedResults,
+    hasActiveFilters,
     showInflationPrice,
     setShowInflationPrice,
   };


### PR DESCRIPTION
## Summary
- Adds a "Share My Top Picks" button that copies a human-readable text card of the top 5 filtered/sorted results plus the shareable URL to the clipboard
- Per feedback on #573, the button only renders once a filter is active (not just whenever there are results) — an unfiltered league table isn't a personal recommendation worth sharing
- Follows the existing `copyShareableLink` pattern (`navigator.clipboard.writeText` + copied/reset timeout)

Closes #573

## Test plan
- [x] `yarn vitest run src/components/sort-posts` — 23 passed, including a new test covering the button appearing/disappearing with filters and its clipboard content
- [x] `yarn tsc --noEmit`
- [x] `yarn biome check` (no new issues)
