### PR TITLE
Remove abandoned preferred-locations commented-out section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -390,36 +390,6 @@ if (roastStatsSinglePage) {
       }
     </ul>
   </section>
-  <!-- <section class="home-list preferred-locations">
-    <p>
-      Select your preferred location from the list below and we'll highlight appropriate reviews to
-      you in the future.
-    </p>
-
-    <div class="custom-select">
-      <button class="dropdown-btn" id="dropdown-btn">Select Locations</button>
-      <div class="dropdown-content">
-        {
-          allLocations.map((location) => (
-            <label class="dropdown-item">
-              <input
-                type="checkbox"
-                value={location.slug}
-                class="hidden-checkbox location-checkbox"
-                data-location={location.slug}
-              />
-              <span>{location.name}</span>
-            </label>
-          ))
-        }
-      </div>
-    </div>
-    <div id="selected-locations">
-      <p>Your selected locations:</p>
-      <ul id="selected-locations-list"></ul>
-    </div>
-  </section> -->
-
   <section class="home" aria-labelledby="search-heading">
     <h2 id="search-heading">Search:</h2>
     <Search resultLimit={4} />


### PR DESCRIPTION
## Summary
- Removed a 29-line HTML comment block from `src/pages/index.astro` (lines 393–421) that contained an abandoned "preferred locations" filtering UI section
- The commented-out code referenced `allLocations` — a variable never declared in the file's active frontmatter — making it broken if ever uncommented
- No surrounding code was changed; this is a pure dead code removal

## Category
Dead code — commented-out code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011W1UWCkYsJxiVtbxShdU9j)_