### PR TITLE
verify sort-posts restores sort and filter state from URL query params

### DIFF
--- a/src/components/sort-posts/sort-posts.test.tsx
+++ b/src/components/sort-posts/sort-posts.test.tsx
@@ -819,4 +819,56 @@ describe("sort-posts component", () => {
       root.unmount();
     });
   });
+
+  describe("URL state initialization", () => {
+    test("initializes sort column and order from URL query params", async () => {
+      window.history.replaceState(null, "", "?sort=price&order=asc");
+      const { host, root } = createHost();
+
+      await act(async () => {
+        root.render(<SortPosts posts={posts} />);
+      });
+      await waitForRender();
+
+      // With price asc, cheapest first: Alpha Arms £18, Bravo House £21, Charlie Tavern £25
+      expect(getRoastTitles(host)).toEqual(["Alpha Arms", "Bravo House", "Charlie Tavern"]);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    test("initializes active meat filter from URL query params", async () => {
+      window.history.replaceState(null, "", "?meat=Beef");
+      const { host, root } = createHost();
+
+      await act(async () => {
+        root.render(<SortPosts posts={posts} />);
+      });
+      await waitForRender();
+
+      expect(getRoastTitles(host)).toEqual(["Alpha Arms"]);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    test("falls back to default sort when URL contains invalid sort params", async () => {
+      window.history.replaceState(null, "", "?sort=nonexistent&order=invalid");
+      const { host, root } = createHost();
+
+      await act(async () => {
+        root.render(<SortPosts posts={posts} />);
+      });
+      await waitForRender();
+
+      // Default: rating desc — Charlie Tavern 9.4, Bravo House 8.0, Alpha Arms 7.1
+      expect(getRoastTitles(host)).toEqual(["Charlie Tavern", "Bravo House", "Alpha Arms"]);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds 3 new tests to `sort-posts.test.tsx` in a `"URL state initialization"` describe block
- Covers the "shareable link" flow in reverse: verifies that the component reads `?sort`, `?order`, and `?meat` query params on mount and restores sort column, sort order, and filter state accordingly
- Also covers the guard branches in `isSortColumn`/`isSortOrder` — if invalid params are in the URL, the component falls back to the default (rating descending)

## What bug this catches

If `getInitialStateFromUrl()` (in `useSortFilter.tsx`) were broken (e.g., always returning `null`), all 492 pre-existing tests would still pass. These three tests would fail, surfacing the regression before it ships.

Test count: 492 → 495.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcMwQN3rBSBjdayE26oAq8)_