### PR TITLE
verify area and borough filters apply simultaneously with AND logic

### DIFF
--- a/src/components/best-value/best-value.test.tsx
+++ b/src/components/best-value/best-value.test.tsx
@@ -281,4 +281,74 @@ describe("best-value component", () => {
       root.unmount();
     });
   });
+
+  test("applies area and borough filters simultaneously, keeping only posts matching both", async () => {
+    const combinedFilterPosts: Post[] = [
+      {
+        date: "2026-01-01",
+        title: "Matches Both",
+        slug: "matches-both",
+        ratings: { nodes: [{ name: "8" }] },
+        prices: { nodes: [{ name: "£15" }] },
+        areas: { nodes: [{ name: "Soho" }] },
+        boroughs: { nodes: [{ name: "Westminster" }] },
+      },
+      {
+        date: "2026-01-01",
+        title: "Matches Area Only",
+        slug: "matches-area-only",
+        ratings: { nodes: [{ name: "7" }] },
+        prices: { nodes: [{ name: "£15" }] },
+        areas: { nodes: [{ name: "Soho" }] },
+        boroughs: { nodes: [{ name: "Camden" }] },
+      },
+      {
+        date: "2026-01-01",
+        title: "Matches Neither",
+        slug: "matches-neither",
+        ratings: { nodes: [{ name: "9" }] },
+        prices: { nodes: [{ name: "£15" }] },
+        areas: { nodes: [{ name: "Hackney" }] },
+        boroughs: { nodes: [{ name: "Hackney" }] },
+      },
+    ];
+
+    const { host, root } = createHost();
+
+    await act(async () => {
+      root.render(<BestValue posts={combinedFilterPosts} />);
+    });
+    await waitForRender();
+
+    const showOptionsButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show all options / filters")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      showOptionsButton.click();
+    });
+    await waitForRender();
+
+    const areaFilter = host.querySelector('select[name="area"]') as HTMLSelectElement;
+    await act(async () => {
+      areaFilter.value = "Soho";
+      areaFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Matches Both", "Matches Area Only"]);
+
+    const boroughFilter = host.querySelector('select[name="borough"]') as HTMLSelectElement;
+    await act(async () => {
+      boroughFilter.value = "Westminster";
+      boroughFilter.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await waitForRender();
+
+    expect(getVenueNames(host)).toEqual(["Matches Both"]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## What was tested and why

The `best-value` component's `filterScoredPosts` helper applies area, borough, and tube-line filters with AND logic — a post must match every active filter to appear. No existing test verified this: each test applied only one filter at a time, so a regression that changed the AND to OR would have passed undetected.

The new test adds three posts with distinct area/borough combinations, applies an area filter (narrows to two), then adds a borough filter (narrows to one), and asserts only the post matching **both** criteria is shown.

## What bug it would catch

If `filterScoredPosts` were changed to use OR instead of AND across filter criteria, the wrong posts would appear when multiple filters are active — but all prior single-filter tests would still pass.

## Test count

Before: 492 tests across 125 files  
After: 493 tests across 125 files

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUGQUYMVT6uvXr515U9GqR)_